### PR TITLE
Patched !welcome script (default name and API pagination)

### DIFF
--- a/scripts/welcome.js
+++ b/scripts/welcome.js
@@ -1,9 +1,10 @@
 // Description
 //   Welcomes new users to UQCS Slack and check for member milestones
 
-var MEMBER_MILESTONE = 50;
-var MESSAGE_PAUSE = 2500;
-var WELCOME_MESSAGES = [
+var API_LIMIT = 200;        // Number of members to get at a time
+var MEMBER_MILESTONE = 50;  // Number of members between posting a celebration
+var MESSAGE_PAUSE = 2500;   // Number of seconds between sending bot messages
+var WELCOME_MESSAGES = [    // Welcome messages sent to new members
     "Hey there! Welcome to the UQCS slack!",
     "This is the first time I've seen you, so you're probably new here",
     "I'm UQCSbot, your friendly (open source) robot helper",
@@ -13,6 +14,29 @@ var WELCOME_MESSAGES = [
     "and again, welcome :)"
 ];
 
+function getNumMembers(robot, room, numMembers, cursor) {
+    // No more members to get, return the final count
+    if (cursor == "") {
+        return Promise.resolve(numMembers);
+    }
+
+    // Request for next batch of users
+    options = {limit: API_LIMIT, cursor: cursor};
+    return robot.adapter.client.web.conversations.members(announcements, options).then(res => {
+        // Create a list of promises that resolve to each member's status
+        var memberPromises = res.members.map(id => {
+            return robot.adapter.client.web.users.info(id)
+                .then(user => (user.deleted) ? 0 : 1);
+            });
+
+        // Count this batch of users, filtering out all who are deleted, and request next batch
+        nextCursor = res.response_metadata.next_cursor;
+        return Promise.all(memberPromises)
+            .then(statuses => statuses.reduce((a, b) => a + b, 0))
+            .then(count => getNumMembers(robot, announcements, numMembers + count, nextCursor));
+    });
+}
+
 module.exports = function (robot) {
     robot.enter(function (res) {
         // Make sure we have access to all the clients we need
@@ -20,37 +44,30 @@ module.exports = function (robot) {
             return;
         }
 
-        // Check the user has entered general
-        var general = robot.adapter.client.rtm.dataStore.getChannelByName("general").id; 
-        if (res.message.room != general) {
+        // Check if user has entered #announcements channel
+        var announcements = robot.adapter.client.rtm.dataStore.getChannelByName("announcements").id; 
+        if (res.message.room != announcements) {
             return;
         }
         
-        // Welcome them to general and send them a personal welcome
-        res.send("Welcome, " + res.message.user.profile.display_name + "!");
+        // Welcome new user to #general
+        var general = robot.adapter.client.rtm.dataStore.getChannelByName("general").id; 
+        name = res.message.user.profile.display_name || res.message.user.name;
+        robot.send({room: general}, "Welcome " + name + "!");
+
+        // Welcome new user personally
         WELCOME_MESSAGES.forEach((message, i) => setTimeout(() => {
             robot.send({room: res.message.user.id}, message);
         }, i * MESSAGE_PAUSE));
 
-        // Check member count to see if we've hit a member milestone
-        robot.adapter.client.web.conversations.members(general).then(result => {
-            // Create a list of promises that resolve to each member's status
-            var memberPromises = result.members.map(id => {
-                return robot.adapter.client.web.users.info(id)
-                    .then(user => (user.deleted) ? 0 : 1);
-                });
+        // Get member count to see if we've hit a member milestone
+        getNumMembers(robot, announcements, 0).then(memberCount => {
+            // If we're not at a member milestone, don't bother celebrating!
+            if (memberCount % MEMBER_MILESTONE != 0) {
+                return;
+            }
 
-            // Get accurate sum of users, filtering out all who are deleted
-            Promise.all(memberPromises)
-                .then(statuses => statuses.reduce((a, b) => a + b, 0))
-                .then(memberCount => {
-                    // If we're not at a member milestone, don't bother celebrating!
-                    if (memberCount % MEMBER_MILESTONE != 0) {
-                        return;
-                    }
-
-                    res.send(":tada: " + memberCount + " members! :tada:");
-                });
-        });
+            res.send(":tada: " + memberCount + " members! :tada:");
+        }).catch(err => console.log(err));
     });
 };

--- a/scripts/welcome.js
+++ b/scripts/welcome.js
@@ -20,9 +20,8 @@ function getMemberCount(robot, room, memberCount, cursor) {
         return Promise.resolve(memberCount);
     }
 
-    // Request for next batch of users
-    options = {limit: API_LIMIT, cursor: cursor};
-    return robot.adapter.client.web.conversations.members(room, options)
+    // Increment member count and request for next batch of users
+    return robot.adapter.client.web.conversations.members(room, {limit: API_LIMIT, cursor: cursor})
         .then(res => getMemberCount(robot, room, memberCount + res.members.length, res.response_metadata.next_cursor));
 }
 

--- a/scripts/welcome.js
+++ b/scripts/welcome.js
@@ -56,6 +56,6 @@ module.exports = function (robot) {
             }
 
             res.send(":tada: " + memberCount + " members! :tada:");
-        }).catch(err => console.log(err));
+        }).catch(console.log);
     });
 };


### PR DESCRIPTION
As per title, fixes two bugs from #166

1) display_name is optional, so instead we now default to `display_name` and resort to `name` as a back up (which is a required field)
2) Slack Web API default limits `conversations.members` to returning only 100 members. Added pagination code that utilises `next_cursor` to accurately yield _all_ members