### PR TITLE
Added manual :wave: to welcome.js

### DIFF
--- a/scripts/welcome.js
+++ b/scripts/welcome.js
@@ -41,7 +41,8 @@ module.exports = function (robot) {
         // Welcome new user to #general
         var general = robot.adapter.client.rtm.dataStore.getChannelByName("general").id; 
         name = res.message.user.profile.display_name || res.message.user.name;
-        robot.send({room: general}, "Welcome " + name + "!");
+        robot.send({room: general}, "Welcome " + name + "!")[0]
+            .then(res => robot.adapter.client.web.reactions.add('wave', {channel: general, timestamp: res.ts}));
 
         // Welcome new user personally
         WELCOME_MESSAGES.forEach((message, i) => setTimeout(() => {


### PR DESCRIPTION
When a user is welcomed to general, uqcsbot's welcome message will prevent wavie.js from :wave:ing at the user due to it becoming the new 'latest' message before the API request can be responded to.

To fix this, I have manually added a :wave: in welcome.js so that new #general users can be waved at :)