### PR TITLE
added a subscriber system to !stats

### DIFF
--- a/scripts/stats.js
+++ b/scripts/stats.js
@@ -3,7 +3,7 @@
 //
 // Commands:
 //   `!stats (rooms|commands|<STAT>)` - Yields general slack statistics for analysis and insight
-//   `!stats (subscribe|unsubscribe) (rooms|commands|<STAT>)` - Subscribes/Unsubscribes user from the given stats
+//   `!stats (subscribe|unsubscribe) (rooms|commands|<STAT>)` - Subscribes/Unsubscribes user from the given stat
 
 var HubotCron = require('hubot-cronjob');
 
@@ -56,8 +56,13 @@ function getStats(robot) {
 function getStat(stats, stat) {
     // Loop over object attributes
     for (var s in stats) {
-        var v = stats[s];
+        // If the stat is a private one, skip it
+        if (s[0] == '_') {
+            continue;
+        }
+
         // If the attribute is the stat we're looking for, return it and its value
+        var v = stats[s];
         if (s == stat) {
             return [s, v]
         }

--- a/scripts/stats.js
+++ b/scripts/stats.js
@@ -182,17 +182,18 @@ function printStat(robot, user, stats, stat) {
 function sendToSubscribers(robot) {
     var stats = getStats(robot);
     var subscribers = stats._subscribers;
-    console.log('subscribers: ' + JSON.stringify(subscribers));
     for (var subscriber in subscribers) {
+        var user = {id: subscriber};
         var subscriptions = subscribers[subscriber];
-        message = `Here are your weekly subscriptions to \`${subscriptions.join(', ')}\`:`;
-        robot.send({room: subscriber}, message)[0].then(() => (0)); // No op to ensure this is sent first
-        subscriptions.forEach(subscription => {
-            switch (subscription) {
-                case 'rooms':    printRoomStat(robot, {id: subscriber}, stats.rooms);       break;
-                case 'commands': printCommandStat(robot, {id: subscriber}, stats.commands); break;
-                default:         printStat(robot, {id: subscriber}, stats, subscription);
-            }
+        message = `Here are your weekly subscriptions to \`${subscriptions.join(', ')}\`!`;
+        robot.send({room: subscriber}, message)[0].then(() => {
+            subscriptions.forEach(subscription => {
+                switch (subscription) {
+                    case 'rooms':    printRoomStat(robot, user, stats.rooms);       break;
+                    case 'commands': printCommandStat(robot, user, stats.commands); break;
+                    default:         printStat(robot, user, stats, subscription);
+                }
+            });
         });
     }
 }

--- a/scripts/stats.js
+++ b/scripts/stats.js
@@ -3,7 +3,7 @@
 //
 // Commands:
 //   `!stats (rooms|commands|<STAT>)` - Yields general slack statistics for analysis and insight
-//   `!stats (subscribe|unsubscribe) (rooms|commands|<STAT>)` - Subscribes/Unsubscribes user from the given stat
+//   `!stats (subscribe|unsubscribe) (rooms|commands|<STAT>)` - Subscribes/Unsubscribes the user to/from the given stat. Subscriptions publish weekly results to subscribers
 
 var HubotCron = require('hubot-cronjob');
 

--- a/scripts/stats.js
+++ b/scripts/stats.js
@@ -135,7 +135,8 @@ function printCommandStat(robot, user, commands) {
     // Build and send output message
     var message = `>>> _${totalCalls} total call(s)_\n\n`;
     sortedCommands.forEach(commandEntry => {
-        message += `*${commandEntry[0]}*: ${commandEntry[1]} call(s)\n`; 
+        percentage =  Math.round(commandEntry[1] / totalCalls * 100);
+        message += `*${commandEntry[0]}*: ${commandEntry[1]} call(s) \`(${percentage}%)\`\n`;
     });
     robot.send({room: user.id}, message);
 }
@@ -161,7 +162,8 @@ function printRoomStat(robot, user, rooms) {
     Promise.all(sortedRoomPromises).then(sortedNamedRooms => {
         var message = `>>> _${totalMessages} total message(s)_\n\n`;
         sortedNamedRooms.forEach(roomEntry => {
-            message += `*${roomEntry[0]}*: ${roomEntry[1]} message(s)\n`; 
+            percentage =  Math.round(roomEntry[1] / totalMessages * 100);
+            message += `*${roomEntry[0]}*: ${roomEntry[1]} message(s) \`(${percentage}%)\`\n`; 
         })
         robot.send({room: user.id}, message);
     }).catch(err => console.log(err));

--- a/scripts/stats.js
+++ b/scripts/stats.js
@@ -171,9 +171,7 @@ function printCommandStat(robot, user, commands) {
 
     // Build and send output message
     var message = `>>> _${totalCalls} total call(s)_ since Monday\n\n`;
-    sortedCommands.forEach(commandEntry => {
-        var command = commandEntry[0];
-        var numCalls = commandEntry[1];
+    sortedCommands.forEach(([commandEntry, numCalls]) => {
         percentage =  Math.round(numCalls / totalCalls * 100);
         message += `*${command}*: ${numCalls} call(s) \`(${percentage}%)\`\n`;
     });
@@ -193,9 +191,7 @@ function printRoomStat(robot, user, rooms) {
 
     // Build and send output message
     var message = `>>> _${totalMessages} total message(s) in ${sortedRooms.length} room(s)_ since Monday\n\n`;
-    sortedRooms.forEach(roomEntry => {
-        var channelId = roomEntry[0];
-        var numMessages = roomEntry[1];
+    sortedRooms.forEach(([channelId, numMessages]) => {
         var channelName = robot.adapter.client.rtm.dataStore.getChannelById(channelId).name;
         percentage =  Math.round(numMessages / totalMessages * 100);
         message += `*${channelName}*: ${numMessages} message(s) \`(${percentage}%)\`\n`; 

--- a/scripts/stats.js
+++ b/scripts/stats.js
@@ -170,7 +170,7 @@ function printCommandStat(robot, user, commands) {
     var totalCalls = sortedCommands.reduce((sum, entry) => sum + entry[1], 0);
 
     // Build and send output message
-    var message = `>>> _${totalCalls} total call(s)_\n\n`;
+    var message = `>>> _${totalCalls} total call(s)_ since Monday\n\n`;
     sortedCommands.forEach(commandEntry => {
         var command = commandEntry[0];
         var numCalls = commandEntry[1];
@@ -192,7 +192,7 @@ function printRoomStat(robot, user, rooms) {
     var totalMessages = sortedRooms.reduce((sum, entry) => sum + entry[1], 0);
 
     // Build and send output message
-    var message = `>>> _${totalMessages} total message(s) in ${sortedRooms.length} room(s)_\n\n`;
+    var message = `>>> _${totalMessages} total message(s) in ${sortedRooms.length} room(s)_ since Monday\n\n`;
     sortedRooms.forEach(roomEntry => {
         var channelId = roomEntry[0];
         var numMessages = roomEntry[1];
@@ -207,7 +207,7 @@ function printRoomStat(robot, user, rooms) {
 function printStat(robot, user, stats, stat) {
     var statEntry = getStat(stats, stat);
     if (!!statEntry) {
-        var message = `>>>*${statEntry[0]}*: ${statEntry[1]}`;
+        var message = `>>>*${statEntry[0]}*: ${statEntry[1]} since Monday`;
     } else {
         var message = `Could not find requested stat \`${stat}\``;
     }

--- a/scripts/stats.js
+++ b/scripts/stats.js
@@ -92,10 +92,10 @@ function handleRoomStat(stats, res) {
 
 // Handles command stat 
 function handleCommandStat(stats, res) {
-    // If the room is not a public channel, exit
+    // If the room is not a public channel or the message is not a command, exit
     var command = res.message.text;
     var room = res.message.room;
-    if (room[0] != 'C') {
+    if (room[0] != 'C' || command[0] != '!') {
         return;
     }
 

--- a/scripts/stats.js
+++ b/scripts/stats.js
@@ -92,16 +92,11 @@ function handleRoomStat(stats, res) {
 
 // Handles command stat 
 function handleCommandStat(stats, res) {
-    // If the command is not actually a command or the room is a private channel, exit
+    // If the room is not a public channel, exit
     var command = res.message.text;
     var room = res.message.room;
-    if ((command[0] != '!' && room[0] != 'D') || room[0] == 'G') {
+    if (room[0] != 'C') {
         return;
-    }
-
-    // If we're talking to uqcsbot, remove the implicit uqcsbot call
-    if (command.indexOf('uqcsbot') == 0) {
-        command = command.replace('uqcsbot ', '');
     }
 
     // Strip down to just the base command

--- a/scripts/stats.js
+++ b/scripts/stats.js
@@ -20,13 +20,13 @@ function incrementCounter(map, entry) {
     map[entry]++;
 }
 
-// Increment counter in map, first setting to 0 if it does not exist
+// Add item to list, first setting as list if one does not exist
 function addToList(map, entry, item) {
     if (!(entry in map)) map[entry] = [];
     map[entry].push(item);
 }
 
-// Increment counter in map, first setting to 0 if it does not exist
+// Removes item from list, returning true if successful else false
 function removeFromList(map, entry, item) {
     if (!(entry in map)) return false;
     var index = map[entry].indexOf(item);
@@ -54,12 +54,15 @@ function getStats(robot) {
 
 // Returns the requested stat, else null
 function getStat(stats, stat) {
+    // Loop over object attributes
     for (var s in stats) {
         var v = stats[s];
+        // If the attribute is the stat we're looking for, return it and its value
         if (s == stat) {
             return [s, v]
         }
 
+        // If the value is another object, recurse into it
         if (typeof v === 'object') {
             result = getStat(v, stat);
             if (!!result) {
@@ -105,12 +108,8 @@ function handleCommandStat(stats, res) {
 // Subscribes the user to the requested stat
 function subscribeToStat(robot, user, subscribers, stat) {
     var stat = stat.replace('subscribe ', '');
-    var message = `Could not subscribe to \`${stat}\``;
-    if (stat[0] != '_') {
-        addToList(subscribers, user.id, stat);
-        message = `Subscribed to \`${stat}\``;
-    }
-    robot.send({room: user.id}, message);
+    addToList(subscribers, user.id, stat);
+    robot.send({room: user.id}, `Subscribed to \`${stat}\``);
 }
 
 // Unsubscribes the user from the requested stat

--- a/scripts/stats.js
+++ b/scripts/stats.js
@@ -197,7 +197,7 @@ function printRoomStat(robot, user, rooms) {
 
     // Attempt to resolve all promises to build and send output message
     Promise.all(sortedRoomPromises).then(sortedNamedRooms => {
-        var message = `>>> _${totalMessages} total message(s)_\n\n`;
+        var message = `>>> _${totalMessages} total message(s) in ${sortedRooms.length} rooms_\n\n`;
         sortedNamedRooms.forEach(roomEntry => {
             percentage =  Math.round(roomEntry[1] / totalMessages * 100);
             message += `*${roomEntry[0]}*: ${roomEntry[1]} message(s) \`(${percentage}%)\`\n`; 

--- a/scripts/stats.js
+++ b/scripts/stats.js
@@ -197,7 +197,7 @@ function printRoomStat(robot, user, rooms) {
 
     // Attempt to resolve all promises to build and send output message
     Promise.all(sortedRoomPromises).then(sortedNamedRooms => {
-        var message = `>>> _${totalMessages} total message(s) in ${sortedRooms.length} rooms_\n\n`;
+        var message = `>>> _${totalMessages} total message(s) in ${sortedRooms.length} room(s)_\n\n`;
         sortedNamedRooms.forEach(roomEntry => {
             percentage =  Math.round(roomEntry[1] / totalMessages * 100);
             message += `*${roomEntry[0]}*: ${roomEntry[1]} message(s) \`(${percentage}%)\`\n`; 

--- a/scripts/stats.js
+++ b/scripts/stats.js
@@ -108,7 +108,9 @@ function handleCommandStat(stats, res) {
 function subscribeToStat(robot, user, subscribers, stat) {
     var stat = stat.replace('subscribe ', '');
     addToList(subscribers, user.id, stat);
-    robot.send({room: user.id}, `Subscribed to \`${stat}\``);
+    message = `Subscribed to \`${stat}\`, ` +
+              `you are now subscribed to \`${subscribers[user.id].join(', ')}\``;
+    robot.send({room: user.id}, message);
 }
 
 // Unsubscribes the user from the requested stat
@@ -116,7 +118,8 @@ function unsubscribeFromStat(robot, user, subscribers, stat) {
     var stat = stat.replace('unsubscribe ', '');
     var message = `Could not find requested subscription \`${stat}\``;
     if (removeFromList(subscribers, user.id, stat)) {
-        message = `Unsubscribed from \`${stat}\``;
+        message = `Unsubscribed from \`${stat}\`, ` +
+                  `you are now subscribed to \`${subscribers[user.id].join(', ')}\``;
     }
     robot.send({room: user.id}, message);
 }

--- a/scripts/stats.js
+++ b/scripts/stats.js
@@ -28,14 +28,23 @@ function addToList(map, entry, item) {
 
 // Removes item from list, returning true if successful else false
 function removeFromList(map, entry, item) {
-    if (!(entry in map)) return false;
+    // If entry is not in map, return false
+    if (!(entry in map)) {
+        return false;
+    }
+
+    // If item is not in list, return false
     var index = map[entry].indexOf(item);
-    if (index == -1) return false;
+    if (index < 0) {
+        return false;
+    }
+
+    // Remove item and return true
     map[entry].splice(index, 1);
     return true;
 }
 
-// Returns a sorted list of object entries
+// Returns a sorted list of object entries in descending order
 function getSortedEntries(object) {
     var entries = [];
     for (var entry in object) entries.push([entry, object[entry]])
@@ -106,8 +115,11 @@ function handleCommandStat(stats, res) {
 
 // Subscribes the user to the requested stat
 function subscribeToStat(robot, user, subscribers, stat) {
+    // If no stat specified, exit
     var index = stat.indexOf(' ');
-    if (index < 0) return;
+    if (index < 0) {
+        return;
+    }
 
     var stat = stat.substring(index + 1);
     addToList(subscribers, user.id, stat);
@@ -118,8 +130,11 @@ function subscribeToStat(robot, user, subscribers, stat) {
 
 // Unsubscribes the user from the requested stat
 function unsubscribeFromStat(robot, user, subscribers, stat) {
+    // If no stat specified, exit
     var index = stat.indexOf(' ');
-    if (index < 0) return;
+    if (index < 0) {
+        return;
+    }
 
     var stat = stat.substring(index + 1);
     var message = `Could not find requested subscription \`${stat}\`, ` +

--- a/scripts/stats.js
+++ b/scripts/stats.js
@@ -3,7 +3,7 @@
 //
 // Commands:
 //   `!stats (rooms|commands|<STAT>)` - Yields general slack statistics for analysis and insight
-//   `!stats (subscribe|unsubscribe) (rooms|commands|<STAT>)` - Subscribes/Unsubscribes the user to/from the given stat. Subscriptions publish weekly results to subscribers
+//   `!stats (subscribe|unsubscribe) (rooms|commands|<STAT>)` - Subscribes/Unsubscribes the user to/from the given stat. Subscriptions publish weekly results to subscribers every Monday
 
 var HubotCron = require('hubot-cronjob');
 

--- a/scripts/stats.js
+++ b/scripts/stats.js
@@ -226,8 +226,7 @@ module.exports = function (robot) {
     });
 
     // Send out weekly results to subscribers and reset stats
-    return new HubotCron("2 * * * *", "Australia/Brisbane", function() {
-    // return new HubotCron("0 0 * * 1", "Australia/Brisbane", function() {
+    return new HubotCron("0 0 * * 1", "Australia/Brisbane", function() {
         sendToSubscribers(robot);
         robot.brain.set("stats", DEFAULT_STATS);
     });

--- a/scripts/stats.js
+++ b/scripts/stats.js
@@ -101,7 +101,6 @@ function handleCommandStat(stats, res) {
 
     // Strip down to just the base command
     var baseCommand = command.split(' ')[0];
-
     incrementCounter(stats.commands, baseCommand);
 }
 
@@ -186,10 +185,8 @@ function sendToSubscribers(robot) {
     console.log('subscribers: ' + JSON.stringify(subscribers));
     for (var subscriber in subscribers) {
         var subscriptions = subscribers[subscriber];
-
         message = `Here are your weekly subscriptions to \`${subscriptions.join(', ')}\`:`;
-        robot.send({room: subscriber}, message)[0]
-            .then(() => (0)); // no op waits for Promise to resolve before moving on
+        robot.send({room: subscriber}, message)[0].then(() => (0)); // No op to ensure this is sent first
         subscriptions.forEach(subscription => {
             switch (subscription) {
                 case 'rooms':    printRoomStat(robot, {id: subscriber}, stats.rooms);       break;

--- a/scripts/stats.js
+++ b/scripts/stats.js
@@ -121,14 +121,11 @@ function subscribeToStat(robot, user, subscribers, stat) {
     var stat = stat.substring(index + 1);
     if (addToSet(subscribers, user.id, stat)) {
         var subscriptions = Array.from(subscribers[user.id]);
-        var message = `Subscribed to \`${stat}\`, ` +
-                  `you are now subscribed to \`${subscriptions.join(', ')}\``;
+        var message = `Subscribed to \`${stat}\`, you are now subscribed to \`${subscriptions.join(', ')}\``;
     } else {
         var subscriptions = Array.from(subscribers[user.id]);
-        var message = `Already subscribed to \`${stat}\`, ` +
-                  `you are currently subscribed to \`${subscriptions.join(', ')}\``;
+        var message = `Already subscribed to \`${stat}\`, you are currently subscribed to \`${subscriptions.join(', ')}\``;
     }
-
     robot.send({room: user.id}, message);
 }
 
@@ -212,9 +209,10 @@ function printRoomStat(robot, user, rooms) {
 // Prints out requested stat
 function printStat(robot, user, stats, stat) {
     var statEntry = getStat(stats, stat);
-    var message = `Could not find requested stat \`${stat}\``;
     if (!!statEntry) {
-        message = `>>>*${statEntry[0]}*: ${statEntry[1]}`;
+        var message = `>>>*${statEntry[0]}*: ${statEntry[1]}`;
+    } else {
+        var message = `Could not find requested stat \`${stat}\``;
     }
     robot.send({room: user.id}, message);
 }


### PR DESCRIPTION
This PR does a few things

- Subscription system allowing people to subscribe to stats
- Stats reset and subscriptions published every Monday (might change this to fortnightly?)
- Arbitrary stats can be subscribed to and retrieved (aka `!stats !cat` will return the value associated with the `!cat` stat)
- Adds percentage statistic to room and command printouts
- Moved from API calls to RTM datastore for getting room names to remove the ability to DOS uqcsbot lol
- fixes #199 
- Removes tracking of direct messages to uqcsbot