### PR TITLE
Ensure that any new default stats being added are added to the brain

### DIFF
--- a/scripts/stats.js
+++ b/scripts/stats.js
@@ -8,7 +8,7 @@
 var HubotCron = require('hubot-cronjob');
 
 // Default stats upon reset
-DEFAULT_STATS = {rooms: {}, commands: {}, _subscribers: {}};
+DEFAULT_STATS = ['rooms', 'commands', '_subscribers'];
 
 /////////////////////
 // HELPER COMMANDS //
@@ -42,12 +42,19 @@ function getSortedEntries(object) {
     return entries.sort((a, b) => b[1] - a[1]);
 }
 
+// Returns true if the stats object contains all the default stats, else false
+function hasDefaultStats(stats) {
+    a = new Set(Object.keys(stats));
+    b = new Set(DEFAULT_STATS);
+    return a.size === b.size && [...a].every(stat => b.has(stat));
+}
+
 // Retrieves stored slack stats, setting them to default values if they do not exist
 function getStats(robot) {
     var stats = robot.brain.get('stats');
-    if (!stats) {
-        robot.brain.set('stats', DEFAULT_STATS);
-        stats = robot.brain.get('stats');
+    if (!stats || !hasDefaultStats(stats)) {
+        stats = robot.brain.set('stats', {}).get('stats');
+        DEFAULT_STATS.forEach(stat => stats[stat] = {});
     }
     return stats;
 }
@@ -256,7 +263,7 @@ module.exports = function (robot) {
         sendToSubscribers(robot, stats);
 
         // Reset stats
-        for (var stat in stats) {
+        for (var stat in DEFAULT_STATS) {
             if (stat == '_subscribers') continue;
             stats[stat] = {};
         }

--- a/scripts/stats.js
+++ b/scripts/stats.js
@@ -42,20 +42,13 @@ function getSortedEntries(object) {
     return entries.sort((a, b) => b[1] - a[1]);
 }
 
-// Returns true if the stats object contains all the default stats, else false
-function hasDefaultStats(stats) {
-    a = new Set(Object.keys(stats));
-    b = new Set(DEFAULT_STATS);
-    return a.size === b.size && [...a].every(stat => b.has(stat));
-}
-
-// Retrieves stored slack stats, setting them to default values if they do not exist
+// Retrieves stored slack stats
 function getStats(robot) {
     var stats = robot.brain.get('stats');
-    if (!stats || !hasDefaultStats(stats)) {
-        stats = robot.brain.set('stats', {}).get('stats');
-        DEFAULT_STATS.forEach(stat => stats[stat] = {});
-    }
+    // If we have no stats, initialise them
+    if (!stats) stats = robot.brain.set('stats', {}).get('stats');
+    // If we're missing some default stats, add them
+    DEFAULT_STATS.filter(stat => !(stat in stats)).forEach(stat => stats[stat] = {});
     return stats;
 }
 


### PR DESCRIPTION
Subscription system will currently be broken as `_subscriber` was never added to the brain, and no code was in place to check otherwise.

This PR fixes that (and any future stats added to the system) by checking all default stats are present every time we get stats from the database.

Also fixes a mutation bug (`DEFAULT_STATS` was copied by reference and therefore being mutated-- not a big deal for now but probably not a good thing lol)

Note: this bug slipped through the gaps during testing because I had no database locally-- and this is only an issue to do with persistent storage