### PR TITLE
Added ability to use optional parameters in post_message

### DIFF
--- a/uqcsbot/base.py
+++ b/uqcsbot/base.py
@@ -137,9 +137,9 @@ class UQCSBot(object):
     def async(self):
         return AsyncBotWrapper(self.client)
 
-    def post_message(self, channel: Union[Channel, str], text: str):
+    def post_message(self, channel: Union[Channel, str], text: str, **kwargs):
         channel_id = channel if isinstance(channel, str) else channel.id
-        return self.api.chat.postMessage(channel=channel_id, text=text)
+        return self.api.chat.postMessage(channel=channel_id, text=text, **kwargs)
 
     def _wrap_async(self, fn):
         """


### PR DESCRIPTION
This just allows the use of optional parameters in the bot.post_message function. For example:

```
attachments = [{
            "fallback": "New ticket from Andrea Lee - Ticket #1943: Can't reset my password - https://groove.hq/path/to/ticket/1943",
            "pretext": "New ticket from Andrea Lee",
            "title": "Ticket #1943: Can't reset my password",
            "title_link": "https://groove.hq/path/to/ticket/1943",
            "text": "Help! I tried to reset my password but nothing happened!",
            "color": "#7CD197"
        }]
    bot.post_message(command.channel, "", attachments=attachments)
```
Results in the following message:
![attach_example](https://user-images.githubusercontent.com/24851062/37017087-e19135c4-215a-11e8-91ed-18563d5ab88e.PNG)
