### PR TITLE
Allows python bot to respond to commands in PMs

### DIFF
--- a/uqcsbot/api.py
+++ b/uqcsbot/api.py
@@ -208,22 +208,6 @@ class ChannelWrapper(object):
         self._channels_by_id[chan.id] = chan
         return chan
 
-    def _add_im(self, im_dict: dict) -> Optional[Channel]:
-        if im_dict['is_user_deleted']:
-            return
-
-        # TODO: Name
-        chan = Channel(
-            bot=self._bot,
-            channel_id=im_dict['id'],
-            name='idk_what_you_want_here',
-            is_public=False,
-            is_private=True,
-            is_archived=False
-        )
-        self._channels_by_id[chan.id] = chan
-        return chan
-
     def _initialise(self):
         with self._lock:
             if self._initialised:
@@ -238,7 +222,12 @@ class ChannelWrapper(object):
 
             for page in self._bot.api.im.list.paginate():
                 for im in page['ims']:
-                    self._add_im(im)
+                    if im['is_user_deleted']:
+                        continue
+
+                    im['is_private'] = True
+                    im['name'] = im['id']
+                    self._add_channel(im)
 
             self._initialised = True
 

--- a/uqcsbot/api.py
+++ b/uqcsbot/api.py
@@ -208,6 +208,16 @@ class ChannelWrapper(object):
         self._channels_by_id[chan.id] = chan
         return chan
 
+    def reload_ims(self):
+        for page in self._bot.api.im.list.paginate():
+            for im in page['ims']:
+                if im['is_user_deleted']:
+                    continue
+
+                im['is_private'] = True
+                im['name'] = im['id']
+                self._add_channel(im)
+
     def _initialise(self):
         with self._lock:
             if self._initialised:
@@ -220,14 +230,7 @@ class ChannelWrapper(object):
                 for chan in page['channels']:
                     self._add_channel(chan)
 
-            for page in self._bot.api.im.list.paginate():
-                for im in page['ims']:
-                    if im['is_user_deleted']:
-                        continue
-
-                    im['is_private'] = True
-                    im['name'] = im['id']
-                    self._add_channel(im)
+            self.reload_ims()
 
             self._initialised = True
 

--- a/uqcsbot/api.py
+++ b/uqcsbot/api.py
@@ -2,7 +2,7 @@ from functools import partial
 from slackclient import SlackClient
 import asyncio
 import threading
-from typing import TYPE_CHECKING, List, Iterable, AsyncIterable, AsyncGenerator, Generator, Any, Union, TypeVar
+from typing import TYPE_CHECKING, List, Iterable, AsyncIterable, AsyncGenerator, Generator, Any, Union, TypeVar, Optional
 if TYPE_CHECKING:
     from .base import UQCSBot
 
@@ -208,6 +208,22 @@ class ChannelWrapper(object):
         self._channels_by_id[chan.id] = chan
         return chan
 
+    def _add_im(self, im_dict: dict) -> Optional[Channel]:
+        if im_dict['is_user_deleted']:
+            return
+
+        # TODO: Name
+        chan = Channel(
+            bot=self._bot,
+            channel_id=im_dict['id'],
+            name='idk_what_you_want_here',
+            is_public=False,
+            is_private=True,
+            is_archived=False
+        )
+        self._channels_by_id[chan.id] = chan
+        return chan
+
     def _initialise(self):
         with self._lock:
             if self._initialised:
@@ -219,6 +235,11 @@ class ChannelWrapper(object):
             for page in self._bot.api.channels.list.paginate():
                 for chan in page['channels']:
                     self._add_channel(chan)
+
+            for page in self._bot.api.im.list.paginate():
+                for im in page['ims']:
+                    self._add_im(im)
+
             self._initialised = True
 
     def reload(self):

--- a/uqcsbot/api.py
+++ b/uqcsbot/api.py
@@ -229,7 +229,7 @@ class ChannelWrapper(object):
                     if im['is_user_deleted']:
                         continue
 
-                    im['is_private'] = True
+                    im['name'] = im['id']
                     self._add_channel(im)
 
             self._initialised = True

--- a/uqcsbot/api.py
+++ b/uqcsbot/api.py
@@ -2,7 +2,7 @@ from functools import partial
 from slackclient import SlackClient
 import asyncio
 import threading
-from typing import TYPE_CHECKING, List, Iterable, AsyncIterable, AsyncGenerator, Generator, Any, Union, TypeVar, Optional
+from typing import TYPE_CHECKING, List, Iterable, AsyncIterable, AsyncGenerator, Generator, Any, Union, TypeVar
 if TYPE_CHECKING:
     from .base import UQCSBot
 

--- a/uqcsbot/api.py
+++ b/uqcsbot/api.py
@@ -157,7 +157,7 @@ class Channel(object):
         self.id = channel_id
         self.name = name
         self._member_ids = None
-        self._is_im = is_im
+        self.is_im = is_im
         self.is_public = is_public
         self.is_private = is_private
         self.is_archived = is_archived

--- a/uqcsbot/api.py
+++ b/uqcsbot/api.py
@@ -147,6 +147,7 @@ class Channel(object):
         bot: 'UQCSBot',
         channel_id: str,
         name: str,
+        is_im: bool = False,
         is_public: bool = False,
         is_private: bool = False,
         is_archived: bool = False,
@@ -156,6 +157,7 @@ class Channel(object):
         self.id = channel_id
         self.name = name
         self._member_ids = None
+        self._is_im = is_im
         self.is_public = is_public
         self.is_private = is_private
         self.is_archived = is_archived
@@ -200,6 +202,7 @@ class ChannelWrapper(object):
             bot=self._bot,
             channel_id=chan_dict['id'],
             name=chan_dict['name'],
+            is_im=chan_dict.get('is_im', False),
             is_public=chan_dict.get('is_public', False),
             is_private=chan_dict.get('is_private', False),
             is_archived=chan_dict.get('is_archived', False),
@@ -226,7 +229,6 @@ class ChannelWrapper(object):
                     if im['is_user_deleted']:
                         continue
 
-                    im['name'] = im['id']
                     im['is_private'] = True
                     self._add_channel(im)
 
@@ -259,7 +261,6 @@ class ChannelWrapper(object):
         chan = evt['channel']
 
         chan['name'] = chan['id']
-        chan['is_private'] = True
         self._add_channel(chan)
 
     def _on_member_joined_channel(self, evt):

--- a/uqcsbot/api.py
+++ b/uqcsbot/api.py
@@ -208,7 +208,7 @@ class ChannelWrapper(object):
         self._channels_by_id[chan.id] = chan
         return chan
 
-    def reload_ims(self):
+    def reload_ims(self, *args):
         for page in self._bot.api.im.list.paginate():
             for im in page['ims']:
                 if im['is_user_deleted']:

--- a/uqcsbot/base.py
+++ b/uqcsbot/base.py
@@ -81,8 +81,6 @@ class UQCSBot(object):
 
         self.channels = ChannelWrapper(self)
 
-        self.register_handler('team_join', self.channels.reload_ims)
-
     def _handle_hello(self, evt):
         if evt != {"type": "hello"}:
             self.logger.debug(f"Hello event has unexpected extras: {evt}")

--- a/uqcsbot/base.py
+++ b/uqcsbot/base.py
@@ -81,6 +81,8 @@ class UQCSBot(object):
 
         self.channels = ChannelWrapper(self)
 
+        self.register_handler('team_join', self.channels.reload_ims)
+
     def _handle_hello(self, evt):
         if evt != {"type": "hello"}:
             self.logger.debug(f"Hello event has unexpected extras: {evt}")


### PR DESCRIPTION
Currently the channel list is only build using channels.list but this does not include the private messages the bot has with users. I just added the channels from the im.list. I also added a handler in the bot class which reloads all ims whenever a new team member joins (team_join event). This may cause an issue if the user immediately goes to the PM with the python bot and types a valid command. Not sure how to get around that.

Solution isn't particularly elegant and I am sure there is a lot to be improved.