### PR TITLE
Introduced automatic bot allocation for easier and quicker dev testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Run `python3 -m uqcsbot --local`
 
 If a bot was available, it will now be running on uqcstesting.
 
-## Running the bot in custom Slack team
+## Running the bot in a custom Slack team
 
 1. [Create a Slack workspace](https://slack.com/create)
 2. Run `python3 setup.py install`

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Run `python3 setup.py install`
 
 Run `python3 -m uqcsbot --local`
 
-**Note**: If you're wanting to test/interact with Slack-specific features (e.g. reactions, channels), you _must_ be running the bot with Slack (See next section).
+**Note**: If you're wanting to test/interact with Slack-specific features (e.g. reactions, channels), you _must_ be running the bot with Slack (See following sections).
 
 ## Running the bot in the communal dev Slack team
 
@@ -18,3 +18,16 @@ Run `python3 -m uqcsbot --local`
 2. Run `python3 -m uqcsbot --dev`
 
 If a bot was available, it will now be running on uqcstesting.
+
+## Running the bot in custom Slack team
+
+1. [Create a Slack workspace](https://slack.com/create)
+2. Run `python3 setup.py install`
+3. [Create a new Slack app](https://api.slack.com/apps/)
+4. Add a bot user to your app
+5. Install your app to your workspace. Install App > Install App to Workspace
+6. Copy the Bot User OAuth Access Token and set it as an environment variable under `SLACK_BOT_TOKEN`
+7. Go to Basic Information, copy your Verification Token and set it as an environment variable under `SLACK_VERIFICATION_TOKEN`
+8. Run `python3 -m uqcsbot`
+
+The bot will now be running on your custom Slack.

--- a/README.md
+++ b/README.md
@@ -15,6 +15,6 @@ Run `python3 -m uqcsbot --local`
 ## Running the bot in the communal dev Slack team
 
 1. Ensure you've joined the [uqcstesting Slack team](https://uqcstest-inviter.herokuapp.com/)
-2. Run `python3 -m uqcsbot`
+2. Run `python3 -m uqcsbot --dev`
 
 If a bot was available, it will now be running on uqcstesting.

--- a/README.md
+++ b/README.md
@@ -2,26 +2,19 @@
 
 uqcsbot is a chat bot built in python for use on our [UQCS Slack Team](uqcs.slack.com).
 
-## Setting up the local development environment
+## Setting up the bot
 
-To run the local development environment, make sure you have Python 3 installed.
+Run `python3 setup.py install`
 
-1. Run `python setup.py install`
-2. Run `python -m uqcsbot --dev`
+## Running the bot in a local development environment
 
-## Setting up the remote development environment
+Run `python3 -m uqcsbot --local`
 
-To set everything up make sure you have Python 3 and virtualenv
+**Note**: If you're wanting to test/interact with Slack-specific features (e.g. reactions, channels), you _must_ be running the bot with Slack (See next section).
 
-1. [Create a Slack workspace](https://slack.com/create)
-1. Set up a `virtualenv`. See [virtualenv docs](https://virtualenv.pypa.io/en/stable/) for more information.
-1. Activate the `virtualenv`
-1. `python setup.py install`
-1. [Create a new Slack app](https://api.slack.com/apps/)
-1. Add a bot user to your app
-1. Install your app to your workspace. Install App > Install App to Workspace
-1. Copy the Bot User OAuth Access Token and set it as an environment variable under `SLACK_BOT_TOKEN`
-1. Go to Basic Information, copy your Verification Token and set it as an environment variable under `SLACK_VERIFICATION_TOKEN`
-1. Run `python -m uqcsbot`
+## Running the bot in the communal dev Slack team
 
-The bot should now be running and receiving all slack RTM events.
+1. Ensure you've joined the [uqcstesting Slack team](https://uqcstest-inviter.herokuapp.com/)
+2. Run `python3 -m uqcsbot`
+
+If a bot was available, it will now be running on uqcstesting.

--- a/uqcsbot/__init__.py
+++ b/uqcsbot/__init__.py
@@ -2,10 +2,72 @@ import os
 import sys
 import importlib
 import logging
+import argparse
+import requests
+import random
+import json
+from base64 import b64decode
 from uqcsbot.base import UQCSBot, bot, Command
 
 SLACK_VERIFICATION_TOKEN = os.environ.get("SLACK_VERIFICATION_TOKEN", "")
 SLACK_BOT_TOKEN = os.environ.get("SLACK_BOT_TOKEN", "")
+
+# UQCSTesting bot tokens. Everything is base64 encoded to somewhat circumvent
+# token tracking by GitHub etal.
+#
+# Order: uqcsbot-alpha, uqcsbot-beta, uqcsbot-gamma, uqcsbot-delta
+BOT_TOKENS = {'U9LA6BX8X': b64decode('eG94Yi0zMjYzNDY0MDUzMDMteGpIbFhlamVNUG1McVhRSnNnZFoyZVhT').decode('utf-8'),
+              'U9K81NL7N': b64decode('eG94Yi0zMjUyNzM3NjgyNjAtNFd0SGhRUWhLb3BSVUlJNFJuc0VRRXJL').decode('utf-8'),
+              'U9JJZ1ZJ4': b64decode('eG94Yi0zMjQ2NDUwNjc2MTYtaHNpR3B3S0ZhSnY3bzJrOW43UU9uRXFp').decode('utf-8'),
+              'U9K5W508K': b64decode('eG94Yi0zMjUyMDAxNzAyOTEtTlJvdVVLcWdyVEpVSE9SMjBoUzhBcnhW').decode('utf-8')}
+
+# Mitch's UQCSTesting Slack API Token. No touchie >:(
+API_TOKEN = b64decode('eG94cC0yNjA3ODI2NzQ2MTAtMjYwMzQ1MTQ0NTI5LTMyNTEyMzU5ODExNS01YjdmYjlhYzAyZWYzNDAyNTYyMTJmY2Q2YjQ1NmEyYg==').decode('utf-8')
+
+
+# Returns true if the given user_id is an active bot (i.e. not deleted).
+def is_active_bot(user_id):
+    api_url = 'https://slack.com/api/users.info'
+    response = requests.get(api_url, params={'token': API_TOKEN, 'user': user_id})
+    if response.status_code != requests.codes.ok:
+        return False
+
+    json_contents = json.loads(response.content)
+    user = json_contents['user']
+    return json_contents['ok'] and user['is_bot'] and not user['deleted']
+
+# Returns true if the given user_id is an active bot that is avaible (i.e. is
+# not currently 'active' which would mean it is in use by another user).
+def is_available_bot(user_id):
+    if not is_active_bot(user_id):
+        return False
+
+    api_url = 'https://slack.com/api/users.getPresence'
+    response = requests.get(api_url, params={'token': API_TOKEN, 'user': user_id})
+    if response.status_code != requests.codes.ok:
+        return False
+
+    json_contents = json.loads(response.content)
+    return json_contents['ok'] and json_contents['presence'] == 'away'
+
+# Pings a channel on the UQCSTesting Slack that contains all the available bots,
+# and Mitch. We can poll this channel to find  bots which are 'away' (that is,
+# not currently being used by anyone else) and return their respective
+# BOT_TOKEN.
+def get_test_bot_token():
+    api_url = 'https://slack.com/api/conversations.members?channel=G9JJXHF7S'
+    response = requests.get(api_url, params={'token': API_TOKEN})
+    if response.status_code != requests.codes.ok:
+        return None
+
+    json_contents = json.loads(response.content)
+    if not json_contents['ok']:
+        return None
+
+    for user_id in json_contents['members']:
+        if is_available_bot(user_id):
+            return BOT_TOKENS.get(user_id, None)
+    return None
 
 
 def main():
@@ -18,14 +80,40 @@ def main():
         module = f'uqcsbot.scripts.{sub_file[:-3]}'
         importlib.import_module(module)
 
-    # Run bot
-    # TODO: Make logging command-line configurable
-    if '--dev' in sys.argv:
-        logging.basicConfig(level=logging.DEBUG)
-        bot.run_debug()
+    # Setup the CLI argument parser
+    parser = argparse.ArgumentParser(description='Run UQCSBot')
+    parser.add_argument('--local',
+                        dest='local',
+                        action='store_true',
+                        help='Runs the bot in local (CLI) mode')
+    parser.add_argument('--dev',
+                        dest='dev',
+                        action='store_true',
+                        help='Runs the bot in development mode (auto assigns a '
+                             'bot on the uqcstesting Slack team)')
+    parser.add_argument('--log_level',
+                        dest='log_level',
+                        default='INFO',
+                        help='Specifies the output logging level to be used '
+                             '(i.e. DEBUG, INFO, WARNING, ERROR, CRITICAL)')
+
+    # Retrieve the CLI args
+    args = parser.parse_args()
+    logging.basicConfig(level=args.log_level)
+
+    # Run the bot
+    if args.local:
+        bot.run_cli()
     else:
-        logging.basicConfig(level=logging.INFO)
-        bot.run(SLACK_BOT_TOKEN, SLACK_VERIFICATION_TOKEN)
+        # If in development mode, attempt to allocate an available bot token,
+        # else stick with the default. If no bot could be allocated, exit.
+        bot_token = get_test_bot_token() if args.dev else SLACK_BOT_TOKEN
+        if bot_token is None:
+            print('Something went wrong during bot allocation. '
+                  'Please ensure there are bots available and try again later. '
+                  'Exiting.')
+            sys.exit(1)
+        bot.run(bot_token, SLACK_VERIFICATION_TOKEN)
 
 if __name__ == "__main__":
     main()

--- a/uqcsbot/__init__.py
+++ b/uqcsbot/__init__.py
@@ -3,10 +3,9 @@ import sys
 import importlib
 import logging
 import argparse
-import requests
-import random
-import json
 from base64 import b64decode
+import json
+import requests
 from uqcsbot.base import UQCSBot, bot, Command
 
 SLACK_VERIFICATION_TOKEN = os.environ.get("SLACK_VERIFICATION_TOKEN", "")
@@ -25,39 +24,47 @@ BOT_TOKENS = {'U9LA6BX8X': b64decode('eG94Yi0zMjYzNDY0MDUzMDMteGpIbFhlamVNUG1McV
 API_TOKEN = b64decode('eG94cC0yNjA3ODI2NzQ2MTAtMjYwMzQ1MTQ0NTI5LTMyNTEyMzU5ODExNS01YjdmYjlhYzAyZWYzNDAyNTYyMTJmY2Q2YjQ1NmEyYg==').decode('utf-8')
 
 
-# Returns true if the given user_id is an active bot (i.e. not deleted).
 def is_active_bot(user_id):
+    '''
+    Returns true if the given user_id is an active bot (i.e. not deleted).
+    '''
     api_url = 'https://slack.com/api/users.info'
     response = requests.get(api_url, params={'token': API_TOKEN, 'user': user_id})
-    if response.status_code != requests.codes.ok:
+    if response.status_code != requests.codes['ok']:
         return False
 
     json_contents = json.loads(response.content)
     user = json_contents['user']
     return json_contents['ok'] and user['is_bot'] and not user['deleted']
 
-# Returns true if the given user_id is an active bot that is avaible (i.e. is
-# not currently 'active' which would mean it is in use by another user).
+
 def is_available_bot(user_id):
+    '''
+    Returns true if the given user_id is an active bot that is avaible (i.e. is
+    not currently 'active' which would mean it is in use by another user).
+    '''
     if not is_active_bot(user_id):
         return False
 
     api_url = 'https://slack.com/api/users.getPresence'
     response = requests.get(api_url, params={'token': API_TOKEN, 'user': user_id})
-    if response.status_code != requests.codes.ok:
+    if response.status_code != requests.codes['ok']:
         return False
 
     json_contents = json.loads(response.content)
     return json_contents['ok'] and json_contents['presence'] == 'away'
 
-# Pings a channel on the UQCSTesting Slack that contains all the available bots,
-# and Mitch. We can poll this channel to find  bots which are 'away' (that is,
-# not currently being used by anyone else) and return their respective
-# BOT_TOKEN.
+
 def get_test_bot_token():
+    '''
+    Pings a channel on the UQCSTesting Slack that contains all the available
+    bots, and Mitch. We can poll this channel to find  bots which are 'away'
+    (that is, not currently being used by anyone else) and return their
+    respective BOT_TOKEN.
+    '''
     api_url = 'https://slack.com/api/conversations.members?channel=G9JJXHF7S'
     response = requests.get(api_url, params={'token': API_TOKEN})
-    if response.status_code != requests.codes.ok:
+    if response.status_code != requests.codes['ok']:
         return None
 
     json_contents = json.loads(response.content)

--- a/uqcsbot/__init__.py
+++ b/uqcsbot/__init__.py
@@ -64,13 +64,15 @@ def get_test_bot_token():
     respective BOT_TOKEN.
     '''
     api_url = 'https://slack.com/api/conversations.members'
-    response = requests.get(api_url, params={'token': API_TOKEN, 'channe': SECRET_BOT_MEETING_ROOM})
+    response = requests.get(api_url, params={'token': API_TOKEN, 'channel': SECRET_BOT_MEETING_ROOM})
     if response.status_code != requests.codes['ok']:
-        return None
+        print(f'Error: received status code {response.status.code}')
+        sys.exit(1)
 
     json_contents = json.loads(response.content)
     if not json_contents['ok']:
-        return None
+        print('Error: {0}'.format(json_contents['error']))
+        sys.exit(1)
 
     for user_id in json_contents['members']:
         if is_available_bot(user_id):

--- a/uqcsbot/__init__.py
+++ b/uqcsbot/__init__.py
@@ -19,7 +19,8 @@ BOT_TOKENS = {'U9LA6BX8X': b64decode('eG94Yi0zMjYzNDY0MDUzMDMteGpIbFhlamVNUG1McV
               'U9K81NL7N': b64decode('eG94Yi0zMjUyNzM3NjgyNjAtNFd0SGhRUWhLb3BSVUlJNFJuc0VRRXJL').decode('utf-8'),
               'U9JJZ1ZJ4': b64decode('eG94Yi0zMjQ2NDUwNjc2MTYtaHNpR3B3S0ZhSnY3bzJrOW43UU9uRXFp').decode('utf-8'),
               'U9K5W508K': b64decode('eG94Yi0zMjUyMDAxNzAyOTEtTlJvdVVLcWdyVEpVSE9SMjBoUzhBcnhW').decode('utf-8')}
-
+# Channel group which contains all the bots. Easy way to get all their ids.
+SECRET_BOT_MEETING_ROOM = 'G9JJXHF7S'
 # Mitch's UQCSTesting Slack API Token. No touchie >:(
 API_TOKEN = b64decode('eG94cC0yNjA3ODI2NzQ2MTAtMjYwMzQ1MTQ0NTI5LTMyNTEyMzU5ODExNS01YjdmYjlhYzAyZWYzNDAyNTYyMTJmY2Q2YjQ1NmEyYg==').decode('utf-8')
 
@@ -62,8 +63,8 @@ def get_test_bot_token():
     (that is, not currently being used by anyone else) and return their
     respective BOT_TOKEN.
     '''
-    api_url = 'https://slack.com/api/conversations.members?channel=G9JJXHF7S'
-    response = requests.get(api_url, params={'token': API_TOKEN})
+    api_url = 'https://slack.com/api/conversations.members'
+    response = requests.get(api_url, params={'token': API_TOKEN, 'channe': SECRET_BOT_MEETING_ROOM})
     if response.status_code != requests.codes['ok']:
         return None
 

--- a/uqcsbot/base.py
+++ b/uqcsbot/base.py
@@ -19,7 +19,7 @@ class Command(object):
         self.command_name = command_name
         self.arg = arg
         self.channel = channel
-    
+
     def has_arg(self) -> bool:
         return self.arg is not None
 
@@ -71,6 +71,7 @@ class UQCSBot(object):
         self._executor = concurrent.futures.ThreadPoolExecutor()
         self._evt_loop.set_default_executor(self._executor)
         self.logger = logger or logging.getLogger("uqcsbot")
+        self._evt_loop.set_debug(self.logger.isEnabledFor(logging.DEBUG))
         self._handlers = collections.defaultdict(list)
         self._command_registry = collections.defaultdict(list)
         self._scheduler = AsyncIOScheduler(event_loop=self._evt_loop)
@@ -114,7 +115,7 @@ class UQCSBot(object):
 
     def on_schedule(self, *args, **kwargs):
         return lambda f: self._scheduler.add_job(f, *args, **kwargs)
-    
+
     def register_handler(self, message_type: Optional[str], handler_fn: Callable):
         if message_type is None:
             message_type = ""
@@ -152,7 +153,7 @@ class UQCSBot(object):
     async def run_async(self, fn, *args, **kwargs):
         """
         Private:
-        
+
         Runs a synchronous function in the bot's async executor, tracking it with
         asyncio.
         """
@@ -221,19 +222,18 @@ class UQCSBot(object):
                         break
                 time.sleep(0.5)
 
-    def run_debug(self):
+    def run_cli(self):
         """
-        Run in debug mode
+        Run in local (CLI) mode
         """
-        self.evt_loop.set_debug(True)
 
-        def debug_api_call(method, **kwargs):
+        def cli_api_call(method, **kwargs):
             if method == "chat.postMessage":
                 print(kwargs['text'])
             else:
                 print(kwargs)
 
-        self.api_call = debug_api_call
+        self.api_call = cli_api_call
         with self._async_context():
             while True:
                 response = input("> ")


### PR DESCRIPTION
Previously, users would have to set up their own remote developer environments in order to test slack-specific features. This required jumping through a lot of hoops such as creating their own workspace, adding custom bot integrations and messing with tokens and environment variables.

This PR brings back the communal Slack testing workspace we had for JSbot, with the added improvement of automagical bot allocation. Now, a user simply has to run with the `--dev` flag and a an available bot will be found and allocated to them for immediate use on the uqcstesting Slack.

This is obviously muuuUUUUUCH more beginner friendly by removing a large barrier of entry (complicated dev environment setups) for new developers looking to contribute to UQCSbot.