### PR TITLE
Added !wolfram command

### DIFF
--- a/uqcsbot/scripts/wolfram.py
+++ b/uqcsbot/scripts/wolfram.py
@@ -5,6 +5,7 @@ import json
 
 APP_ID = "UVKV2V-5XW2TETT69"
 
+
 # TODO: Show the assumptions made?
 # TODO: Better naming of commands
 @bot.on_command("wolframfull")
@@ -58,6 +59,7 @@ async def handle_wolfram(command: Command):
         return
 
     bot.post_message(command.channel, http_response.content)
+
 
 # TODO: Should this really be a generator?
 def get_subpods(pods: list) -> Iterable[Tuple[str, dict]]:

--- a/uqcsbot/scripts/wolfram.py
+++ b/uqcsbot/scripts/wolfram.py
@@ -173,7 +173,11 @@ async def short_answer(command: Command):
     bot.post_message(command.channel, http_response.content)
 
 def get_subpods(pods: list) -> Iterable[Tuple[str, dict]]:
-    """Yields sublots in the order they should be displayed"""
+    """
+    Yields subpods in the order they should be displayed
+
+    Yield: (pod_or_subpod_title, subpod)
+    """
     for pod in pods:
         for subpod in pod["subpods"]:
             # Use the pods title if the subpod doesn't have its own title (general case)

--- a/uqcsbot/scripts/wolfram.py
+++ b/uqcsbot/scripts/wolfram.py
@@ -1,11 +1,25 @@
 from uqcsbot import bot, Command
 import requests
+import json
 
-API_URL = r"http://api.wolframalpha.com/v2/query?appid=UVKV2V-5XW2TETT69"
+API_URL = r"http://api.wolframalpha.com/v2/query?appid=UVKV2V-5XW2TETT69&output=json"
+
 
 @bot.on_command("wolfram")
 async def handle_wolfram(command: Command):
     search_query = command.arg
     http_response = await bot.run_async(requests.get, API_URL, params={'input': search_query})
 
-    bot.post_message(command.channel, http_response.content)
+    # Check if the response is ok
+    if http_response.status_code != requests.codes.ok:
+        bot.post_message(command.channel, "There was a problem getting the response")
+        return
+
+    # Get the result of the query and determine if wolfram succeeded in evaluating it
+    # TODO: success and error mean slightly different things. The message could indicate this?
+    result = json.loads(http_response.content)['queryresult']
+    if not result['success'] or result["error"]:
+        bot.post_message(command.channel, "Please rephrase your query. Wolfram could not compute.")
+
+
+

--- a/uqcsbot/scripts/wolfram.py
+++ b/uqcsbot/scripts/wolfram.py
@@ -1,9 +1,10 @@
 from uqcsbot import bot, Command
 from typing import Iterable, Tuple, Optional
+from base64 import b64decode
 import requests
 import json
 
-APP_ID = "UVKV2V-5XW2TETT69"
+APP_ID = b64decode('RzU0S1VBLVVHWTdHR0hWUlg=').decode('utf-8')
 
 # TODO: Better naming of commands
 @bot.on_command("wolframfull")

--- a/uqcsbot/scripts/wolfram.py
+++ b/uqcsbot/scripts/wolfram.py
@@ -2,16 +2,20 @@ from uqcsbot import bot, Command
 from typing import Iterable, Tuple
 import requests
 import json
-import pprint
 
 APP_ID = "UVKV2V-5XW2TETT69"
 
 
-# TODO: Show the assumptions made?
+# IDEA: Show the assumptions made?
 # TODO: Better naming of commands
 @bot.on_command("wolframfull")
 async def handle_wolframfull(command: Command):
-    """This posts the full results from wolfram query. Images and all"""
+    """
+    This posts the full results from wolfram query. Images and all
+
+    Example usage:
+    !wolframfull y = 2x + c
+    """
     api_url = r"http://api.wolframalpha.com/v2/query?&output=json"
     search_query = command.arg
     http_response = await bot.run_async(requests.get, api_url, params={'input': search_query, 'appid': APP_ID})
@@ -22,13 +26,11 @@ async def handle_wolframfull(command: Command):
         return
 
     # Get the result of the query and determine if wolfram succeeded in evaluating it
-    # TODO: success and error mean slightly different things. The message could indicate this?
     result = json.loads(http_response.content)['queryresult']
     if not result['success'] or result["error"]:
         bot.post_message(command.channel, "Please rephrase your query. Wolfram could not compute.")
 
     subpods = get_subpods(result['pods'])
-
     message = ""
     for title, subpod in subpods:
         plaintext = subpod["plaintext"]

--- a/uqcsbot/scripts/wolfram.py
+++ b/uqcsbot/scripts/wolfram.py
@@ -2,6 +2,7 @@ from uqcsbot import bot, Command
 from typing import Iterable, Tuple
 import requests
 import json
+import pprint
 
 APP_ID = "UVKV2V-5XW2TETT69"
 
@@ -85,17 +86,19 @@ async def handle_wolfram(command: Command):
 def handle_reply(evt: dict):
     channel = evt['channel']
 
-    # if 'thread_ts' in evt:
-    #     bot.post_message(channel, evt)
-
-    print(bot.api.channels.info(channel=channel)['channel']['latest'])
-    # We only care about replies to messages that have been set up for conversation
-    if 'subtype' not in evt or evt['subtype'] != 'message_replied':
+    # If the message is not in a thread ignore it
+    if 'thread_ts' not in evt:
         return
 
+    thread_ts = evt['thread_ts']
+    thread_parent = bot.api.conversations.history(channel=channel, limit=1, inclusive=True, latest=thread_ts).paginate()
+    thread_parent = bot.api.conversations.history(limit=1).paginate()
+    bot.post_message(channel, thread_parent)
 
-    bot.post_message(channel, evt)
 
+# @bot.on('message')
+# def temp(evt: dict):
+#     print(evt)
 
 async def short_answer(command: Command):
     """

--- a/uqcsbot/scripts/wolfram.py
+++ b/uqcsbot/scripts/wolfram.py
@@ -1,0 +1,11 @@
+from uqcsbot import bot, Command
+import requests
+
+API_URL = r"http://api.wolframalpha.com/v2/query?appid=UVKV2V-5XW2TETT69"
+
+@bot.on_command("wolfram")
+async def handle_wolfram(command: Command):
+    search_query = command.arg
+    http_response = await bot.run_async(requests.get, API_URL, params={'input': search_query})
+
+    bot.post_message(command.channel, http_response.content)

--- a/uqcsbot/scripts/wolfram.py
+++ b/uqcsbot/scripts/wolfram.py
@@ -6,6 +6,24 @@ import json
 
 APP_ID = b64decode('RzU0S1VBLVVHWTdHR0hWUlg=').decode('utf-8')
 
+
+
+
+def get_subpods(pods: list) -> Iterable[Tuple[str, dict]]:
+    """
+    Yields subpods in the order they should be displayed. A subpod is essentially an element of a wolfram response.
+    For example one pod might be "Visual Representation" and the subpod is a graph of your input. Every pod has at least
+    one subpod (usually only one).
+
+    Yield: (pod_or_subpod_title, subpod)
+    """
+    for pod in pods:
+        for subpod in pod["subpods"]:
+            # Use the pods title if the subpod doesn't have its own title (general case)
+            title = pod['title'] if len(subpod['title']) == 0 else subpod['title']
+            yield (title, subpod)
+
+
 # TODO: Better naming of commands
 @bot.on_command("wolframfull")
 async def handle_wolframfull(command: Command):
@@ -28,10 +46,13 @@ async def handle_wolframfull(command: Command):
     result = json.loads(http_response.content)['queryresult']
     if not result['success'] or result["error"]:
         bot.post_message(command.channel, "Please rephrase your query. Wolfram could not compute.")
+        return
 
-    subpods = get_subpods(result['pods'])
+    # A pod is the name wolfram gives to the different "units" that make up its result.
+    # For example a pod may be a "Visual Representation" of the input. Essentially they are logical components.
+    # Each pod has one or more subpods that compose it.
     message = ""
-    for title, subpod in subpods:
+    for title, subpod in get_subpods(result['pods']):
         plaintext = subpod["plaintext"]
 
         # Prefer a plain text representation to the image
@@ -40,9 +61,28 @@ async def handle_wolframfull(command: Command):
         else:
             image_url = subpod['img']['src']
             image_title = subpod['img']['title']
-            message += f'{image_title}:\n{image_url}\n' if image_title else f'{image_url}\n'
+            message += f'{image_title}:\n{image_url}\n' if len(image_title) != 0 else f'{image_url}\n'
 
     bot.post_message(command.channel, message)
+
+
+async def get_short_answer(search_query: str):
+    """
+    This uses wolfram's short answers api to just return a simple short plaintext response.
+
+    This is used if the conversation api fails to get a result (for instance !wolfram pineapple is not a great
+    conversation starter but may be interesting.
+    """
+    api_url = r"http://api.wolframalpha.com/v1/result?"
+    http_response = await bot.run_async(requests.get, api_url, params={'input': search_query, 'appid': APP_ID})
+
+    # Check if the response is ok. A status code of 501 signifies that no result could be found.
+    if http_response.status_code == 501:
+        return "No short answer available. Try !wolframfull"
+    elif http_response.status_code != requests.codes.ok:
+        return "There was a problem getting the response"
+
+    return http_response.content
 
 
 @bot.on_command("wolfram")
@@ -63,7 +103,7 @@ async def handle_wolfram(command: Command):
     if conversation_id is None:
         if result == "No result is available":
             # If no conversational result is available just return a normal short answer
-            short_response = await short_answer(search_query)
+            short_response = await get_short_answer(search_query)
             bot.post_message(command.channel, short_response)
             return
         else:
@@ -73,6 +113,8 @@ async def handle_wolfram(command: Command):
     # TODO: Is there a better option than storing the id in the fallback?
     # Here we store the conversation ID in the fallback so we can get it back later.
     # We also store an identifier string to check against later and the reply_host and s_output string
+    # Attachments is a slack thing that allows the formatting or more complex messages. In this case we add a footer
+    # and use the fallback to cheekily store information for later.
     attachments = [{
         'fallback': f'WolframCanReply {reply_host} {s_output} {conversation_id}',
         'footer': 'Further questions may be asked',
@@ -80,71 +122,6 @@ async def handle_wolfram(command: Command):
     }]
 
     bot.post_message(command.channel, "", attachments=attachments)
-
-
-@bot.on('message')
-async def handle_reply(evt: dict):
-    # If the message isn't from a thread or is from a bot ignore it (avoid those infinite loops)
-    if 'thread_ts' not in evt or (evt.get('subtype') == 'bot_message'):
-        return
-
-    channel = evt['channel']
-    thread_ts = evt['thread_ts']  # This refers to time the original message
-    thread_parent = bot.api.conversations.history(channel=channel, limit=1, inclusive=True, latest=thread_ts)
-
-    if not thread_parent['ok']:
-        bot.post_message(channel, 'Sorry, something went wrong with slack', thread_ts=thread_ts)
-        return
-
-    # Limit=1 was used so the first (and only) message is what we want
-    parent_message = thread_parent['messages'][0]
-    # If the threads parent wasn't by a bot ignore it
-    if parent_message.get('subtype') != 'bot_message':
-        return
-
-    # Finally, we have to check that this is a Wolfram replyable message
-    # It is rare we would reach this point and not pass as who replies to a bot in a thread for another reason?
-    parent_attachments = parent_message['attachments'][0]  # The message is formatted with only one attachment
-    parent_fallback = parent_attachments['fallback']
-    if 'WolframCanReply' not in parent_fallback:
-        return
-
-    # Now we can grab the conversation_id from the message and get the new question (s only sometimes appears)
-    # Recall the format of the fallback "identifier hostname s_output conversationID"
-    _, reply_host, s_output, conversation_id = parent_fallback.split(' ')
-    new_question = evt['text']  # This is the value of the message that triggered this whole response
-    s_output = '' if s_output == 'null' else s_output
-
-    # Ask Wolfram for the new answer grab the new stuff and post the reply.
-    reply, conversation_id, reply_host, s_output = await conversation_request(new_question, reply_host, conversation_id, s_output)
-
-    bot.post_message(channel, reply, thread_ts=thread_ts)
-
-    # If getting a the conversation request results in an error then conversation_id will be None
-    if conversation_id is not None:
-        # Update the old fallback to reflect the new state of the conversation
-        parent_attachments['fallback'] = f'WolframCanReply {reply_host} {s_output} {conversation_id}'
-
-        bot.api.chat.update(channel=channel, attachments=[parent_attachments], ts=thread_ts)
-
-
-async def short_answer(search_query: str):
-    """
-    This uses wolfram's short answers api to just return a simple short plaintext response.
-
-    This is used if the conversation api fails to get a result (for instance !wolfram pineapple is not a great
-    conversation starter but may be interesting.
-    """
-    api_url = r"http://api.wolframalpha.com/v1/result?"
-    http_response = await bot.run_async(requests.get, api_url, params={'input': search_query, 'appid': APP_ID})
-
-    # Check if the response is ok. A status code of 501 signifies that no result could be found.
-    if http_response.status_code == 501:
-        return "No short answer available. Try !wolframfull"
-    elif http_response.status_code != requests.codes.ok:
-        return "There was a problem getting the response"
-
-    return http_response.content
 
 
 def extract_reply(wolfram_response: dict) -> Tuple[str, str, str, str]:
@@ -192,14 +169,58 @@ async def conversation_request(search_query: str, host_name: Optional[str]=None,
     return extract_reply(wolfram_answer)
 
 
-def get_subpods(pods: list) -> Iterable[Tuple[str, dict]]:
+@bot.on('message')
+async def handle_reply(evt: dict):
     """
-    Yields subpods in the order they should be displayed
+    Handles a message event. Whenever a message is a reply to one of !wolframs conversational results this handles
+    getting the next response and updating the old stored information.
+    """
+    # If the message isn't from a thread or is from a bot ignore it (avoid those infinite loops)
+    if 'thread_ts' not in evt or evt.get('subtype') == 'bot_message':
+        return
 
-    Yield: (pod_or_subpod_title, subpod)
-    """
-    for pod in pods:
-        for subpod in pod["subpods"]:
-            # Use the pods title if the subpod doesn't have its own title (general case)
-            title = subpod['title'] if subpod['title'] else pod['title']
-            yield (title, subpod)
+    channel = evt['channel']
+    thread_ts = evt['thread_ts']  # This refers to time the original message
+    thread_parent = bot.api.conversations.history(channel=channel, limit=1, inclusive=True, latest=thread_ts)
+
+    if not thread_parent['ok']:
+        # The most likely reason for this error is auth issues or possibly rate limiting
+        bot.post_message(channel, 'Sorry, something went wrong with slack', thread_ts=thread_ts)
+        return
+
+    # Limit=1 was used so the first (and only) message is what we want
+    parent_message = thread_parent['messages'][0]
+    # If the threads parent wasn't by a bot ignore it
+    if parent_message.get('subtype') != 'bot_message':
+        return
+
+    # Finally, we have to check that this is a Wolfram replyable message
+    # It is rare we would reach this point and not pass as who replies to a bot in a thread for another reason?
+    parent_attachments = parent_message['attachments'][0]  # The message is formatted with only one attachment
+    parent_fallback = parent_attachments['fallback']
+    if 'WolframCanReply' not in parent_fallback:
+        return
+
+    # Now we can grab the conversation_id from the message and get the new question (s only sometimes appears)
+    # Recall the format of the fallback "identifier hostname s_output conversationID"
+    _, reply_host, s_output, conversation_id = parent_fallback.split(' ')
+    new_question = evt['text']  # This is the value of the message that triggered this whole response
+    s_output = '' if s_output == 'null' else s_output
+
+    # Ask Wolfram for the new answer grab the new stuff and post the reply.
+    reply, conversation_id, reply_host, s_output = await conversation_request(new_question, reply_host, conversation_id, s_output)
+
+    bot.post_message(channel, reply, thread_ts=thread_ts)
+
+    # If getting a the conversation request results in an error then conversation_id will be None
+    if conversation_id is not None:
+        # Update the old fallback to reflect the new state of the conversation
+        parent_attachments['fallback'] = f'WolframCanReply {reply_host} {s_output} {conversation_id}'
+
+        bot.api.chat.update(channel=channel, attachments=[parent_attachments], ts=thread_ts)
+
+
+
+
+
+

--- a/uqcsbot/scripts/wolfram.py
+++ b/uqcsbot/scripts/wolfram.py
@@ -5,7 +5,6 @@ import json
 
 APP_ID = "UVKV2V-5XW2TETT69"
 
-
 # IDEA: Show the assumptions made?
 # TODO: Better naming of commands
 @bot.on_command("wolframfull")
@@ -72,7 +71,7 @@ async def handle_wolfram(command: Command):
         error = wolfram_result['error']
         if error == "No result is available":
             # If no conversational result is available just return a normal short answer
-            short_response = await short_answer()
+            short_response = await short_answer(search_query)
             bot.post_message(command.channel, short_response)
             return
         else:
@@ -82,8 +81,8 @@ async def handle_wolfram(command: Command):
     # Unpack the response in order to construct the reply message
     result = wolfram_result['result']  # This is the answer to our question
     reply_host = wolfram_result['host']  # This is the hostname to ask the next question to
-    conversation_id = wolfram_result['conversationID']  # This is the conversations identifier. Used to continue the conversation
-    s_output = wolfram_result.get('s', None)  # s is only sometimes returned but is vital if it is returned (no idea what is stands for)
+    conversation_id = wolfram_result['conversationID']  # Used to continue the conversation
+    s_output = wolfram_result.get('s', None)  # s is only sometimes returned but is vital if it is returned
 
     # TODO: Is there a better option than storing the id in the fallback?
     # Here we store the conversation ID in the fallback so we can get it back later.
@@ -96,37 +95,37 @@ async def handle_wolfram(command: Command):
 
     bot.post_message(command.channel, "", attachments=attachments)
 
-# TODO: Add 'ok' checks
+
 @bot.on('message')
 async def handle_reply(evt: dict):
     # If the message isn't from a thread or is from a bot ignore it (avoid those infinite loops)
-    if 'thread_ts' not in evt or ('subtype' in evt and evt['subtype'] == 'bot_message'):
+    if 'thread_ts' not in evt or (evt.get('subtype') == 'bot_message'):
         return
 
     channel = evt['channel']
-
-    thread_ts = evt['thread_ts']
+    thread_ts = evt['thread_ts']  # This refers to time the original message
     thread_parent = bot.api.conversations.history(channel=channel, limit=1, inclusive=True, latest=thread_ts)
 
     if not thread_parent['ok']:
         bot.post_message(channel, 'Sorry, something went wrong with slack', thread_ts=thread_ts)
         return
 
-    parent_message = thread_parent['messages'][0]
-    # If the threads parent wasn't by a bot ignore
-    if 'subtype' not in parent_message or parent_message['subtype'] != 'bot_message':
+    parent_message = thread_parent['messages'][0]  # Limit=1 was used so the first (and only) message is what we want
+    # If the threads parent wasn't by a bot ignore it
+    if parent_message.get('subtype') != 'bot_message':
         return
 
     # Finally, we have to check that this is a Wolfram replyable message
-    # It is rare we would reach this point and not pass as who replies to a bot in a thread for another reason
-    parent_attachments = parent_message['attachments'][0]
+    # It is rare we would reach this point and not pass as who replies to a bot in a thread for another reason?
+    parent_attachments = parent_message['attachments'][0]  # The message is formatted with only one attachment
     parent_fallback = parent_attachments['fallback']
     if 'WolframCanReply' not in parent_fallback:
         return
 
     # Now we can grab the conversation_id from the message and get the new question (s only sometimes appears)
+    # Recall the format of the fallback "identifier hostname s_output conversationID"
     _, reply_host, s_output, conversation_id = parent_fallback.split(' ')
-    new_question = evt['text']
+    new_question = evt['text']  # This is the value of the message that triggered this whole response
     s_output = '' if s_output == 'None' else s_output
 
     # Slack annoyingly formats the reply_host link so we have to extract what we want:
@@ -142,27 +141,26 @@ async def handle_reply(evt: dict):
         return
 
     # Convert to json and check for an error
-    json_response = json.loads(http_response.content)
-    if 'error' in json_response:
-        bot.post_message(channel, json_response['error'], thread_ts=thread_ts)
+    wolfram_answer = json.loads(http_response.content)
+    if 'error' in wolfram_answer:
+        bot.post_message(channel, wolfram_answer['error'], thread_ts=thread_ts)
         return
 
     # Otherwise grab the new stuff and post the reply.
-    reply = json_response['result']
-    conversation_id = json_response['conversationID']
-    reply_host = json_response['host']
-    s_output = json_response.get('s', None)
+    reply = wolfram_answer['result']
+    conversation_id = wolfram_answer['conversationID']
+    reply_host = wolfram_answer['host']
+    s_output = wolfram_answer.get('s', None)
 
     bot.post_message(channel, reply, thread_ts=thread_ts)
 
-    # Update the old conversation_id to indicate the new state
-    updated_attachments = parent_attachments.copy()
-    updated_attachments['fallback'] = f'WolframCanReply {reply_host} {s_output} {conversation_id}'
+    # Update the old fallback to reflect the new state of the conversation
+    parent_attachments['fallback'] = f'WolframCanReply {reply_host} {s_output} {conversation_id}'
 
-    bot.api.chat.update(channel=channel, attachments=[updated_attachments], ts=thread_ts)
+    bot.api.chat.update(channel=channel, attachments=[parent_attachments], ts=thread_ts)
 
 
-async def short_answer():
+async def short_answer(search_query: str):
     """
     This uses wolfram's short answers api to just return a simple short plaintext response.
 
@@ -170,18 +168,16 @@ async def short_answer():
     conversation starter but may be interesting.
     """
     api_url = r"http://api.wolframalpha.com/v1/result?"
-    search_query = command.arg
     http_response = await bot.run_async(requests.get, api_url, params={'input': search_query, 'appid': APP_ID})
 
     # Check if the response is ok. A status code of 501 signifies that no result could be found.
     if http_response.status_code == 501:
-        bot.post_message(command.channel, "No short answer available. Try !wolframfull")
-        return
+        return "No short answer available. Try !wolframfull"
     elif http_response.status_code != requests.codes.ok:
-        bot.post_message(command.channel, "There was a problem getting the response")
-        return
+        return "There was a problem getting the response"
 
     return http_response.content
+
 
 def get_subpods(pods: list) -> Iterable[Tuple[str, dict]]:
     """

--- a/uqcsbot/scripts/wolfram.py
+++ b/uqcsbot/scripts/wolfram.py
@@ -79,13 +79,15 @@ async def handle_wolfram(command: Command):
             bot.post_message(command.channel, error)
             return
 
-    result = wolfram_result['result']
-    reply_host = wolfram_result['host']
-    conversation_id = wolfram_result['conversationID']
-    s_output = wolfram_result.get('s', None)
+    # Unpack the response in order to construct the reply message
+    result = wolfram_result['result']  # This is the answer to our question
+    reply_host = wolfram_result['host']  # This is the hostname to ask the next question to
+    conversation_id = wolfram_result['conversationID']  # This is the conversations identifier. Used to continue the conversation
+    s_output = wolfram_result.get('s', None)  # s is only sometimes returned but is vital if it is returned (no idea what is stands for)
 
     # TODO: Is there a better option than storing the id in the fallback?
-    # Here we store the conversation ID in the fallback so we can get it back later. We also store and indicator of this
+    # Here we store the conversation ID in the fallback so we can get it back later.
+    # We also store an identifier string to check against later and the reply_host and s_output string
     attachments = [{
         'fallback': f'WolframCanReply {reply_host} {s_output} {conversation_id}',
         'footer': 'Further questions may be asked',

--- a/uqcsbot/scripts/wolfram.py
+++ b/uqcsbot/scripts/wolfram.py
@@ -71,16 +71,31 @@ async def handle_wolfram(command: Command):
     result = json_response['result']
     conversation_id = json_response['conversationID']
 
-    attachments = [{'footer': str(conversation_id)}]
-    bot.post_message(command.channel, result, attachments=attachments)
+    # TODO: Is there a better option than storing the id in the fallback?
+    # TODO: The footer is actually used in a check in handle_reply. This is probably fine unless someone else uses this footer but why would they? In any case a better solution would be good. Another non visible field would work.
+    attachments = [{
+        'fallback': conversation_id,
+        'footer': 'Further questions may be asked',
+        'text': result
+    }]
+
+    bot.post_message(command.channel, "", attachments=attachments)
 
 @bot.on('message')
 def handle_reply(evt: dict):
+    channel = evt['channel']
+
+    # if 'thread_ts' in evt:
+    #     bot.post_message(channel, evt)
+
+    print(bot.api.channels.info(channel=channel)['channel']['latest'])
     # We only care about replies to messages that have been set up for conversation
     if 'subtype' not in evt or evt['subtype'] != 'message_replied':
         return
 
-    bot.post_message(evt['channel'], evt)
+
+    bot.post_message(channel, evt)
+
 
 async def short_answer(command: Command):
     """

--- a/uqcsbot/scripts/wolfram.py
+++ b/uqcsbot/scripts/wolfram.py
@@ -7,8 +7,6 @@ import json
 APP_ID = b64decode('RzU0S1VBLVVHWTdHR0hWUlg=').decode('utf-8')
 
 
-
-
 def get_subpods(pods: list) -> Iterable[Tuple[str, dict]]:
     """
     Yields subpods in the order they should be displayed. A subpod is essentially an element of a wolfram response.
@@ -33,7 +31,7 @@ async def handle_wolframfull(command: Command):
     Example usage:
     !wolframfull y = 2x + c
     """
-    api_url = r"http://api.wolframalpha.com/v2/query?&output=json"
+    api_url = "http://api.wolframalpha.com/v2/query?&output=json"
     search_query = command.arg
     http_response = await bot.run_async(requests.get, api_url, params={'input': search_query, 'appid': APP_ID})
 
@@ -73,7 +71,7 @@ async def get_short_answer(search_query: str):
     This is used if the conversation api fails to get a result (for instance !wolfram pineapple is not a great
     conversation starter but may be interesting.
     """
-    api_url = r"http://api.wolframalpha.com/v1/result?"
+    api_url = "http://api.wolframalpha.com/v2/result?"
     http_response = await bot.run_async(requests.get, api_url, params={'input': search_query, 'appid': APP_ID})
 
     # Check if the response is ok. A status code of 501 signifies that no result could be found.
@@ -218,9 +216,3 @@ async def handle_reply(evt: dict):
         parent_attachments['fallback'] = f'WolframCanReply {reply_host} {s_output} {conversation_id}'
 
         bot.api.chat.update(channel=channel, attachments=[parent_attachments], ts=thread_ts)
-
-
-
-
-
-

--- a/uqcsbot/scripts/wolfram.py
+++ b/uqcsbot/scripts/wolfram.py
@@ -46,19 +46,21 @@ async def handle_wolframfull(command: Command):
 @bot.on_command("wolfram")
 async def handle_wolfram(command: Command):
     """This uses wolframs short answers api to just return a simple short plaintext response"""
-    api_url = r"http://api.wolframalpha.com/v1/result?"
+    api_url = r"http://api.wolframalpha.com/v1/conversation.jsp"
     search_query = command.arg
     http_response = await bot.run_async(requests.get, api_url, params={'input': search_query, 'appid': APP_ID})
 
-    # Check if the response is ok. A status code of 501 signifies that no result could be found.
-    if http_response.status_code == 501:
-        bot.post_message(command.channel, "No short answer available. Try !wolframfull")
-        return
-    elif http_response.status_code != requests.codes.ok:
+    # Check if the response is okay
+    if http_response.status_code != requests.codes.ok:
         bot.post_message(command.channel, "There was a problem getting the response")
         return
 
-    bot.post_message(command.channel, http_response.content)
+    result = json.loads(http_response.content)
+
+    channel_id = command.channel if isinstance(command.channel, str) else command.channel.id
+    a = bot.api.chat.postMessage(channel=channel_id, text="Test message")
+    bot.post_message(command.channel, a)
+
 
 
 # TODO: Should this really be a generator?


### PR DESCRIPTION
A single command !wolfram that does two things. Depending on the --full arg

!wolfram --full 2x+8
!wolfram 2x+8 --full
Examples:
![wolframfull](https://user-images.githubusercontent.com/24851062/37150402-47874210-231d-11e8-9706-3c0c34163320.PNG)

!wolfram on the other hand returns just a short text response that can usually be replied to. For example:

![wolfram1](https://user-images.githubusercontent.com/24851062/37150741-90a280bc-231e-11e8-8105-60d58aaffee1.PNG)
![wolfram2](https://user-images.githubusercontent.com/24851062/37150742-90dcb3ae-231e-11e8-85d8-caba238454b4.PNG)
![wolfram3](https://user-images.githubusercontent.com/24851062/37150744-911472f8-231e-11e8-90e7-c3a4fab53582.PNG)
![wolfram4](https://user-images.githubusercontent.com/24851062/37150745-9149baee-231e-11e8-9d77-ffdf4e7e0229.PNG)

If Wolfram cannot come up with a conversation for that question (seems to be a rare case) then a short answer is instead supplied using their short answers API. 

The app id you get from wolfram is free for less than 2000 requests a month which I doubt would ever be exceeded.