### PR TITLE
Added !help command

### DIFF
--- a/uqcsbot/api.py
+++ b/uqcsbot/api.py
@@ -232,7 +232,10 @@ class ChannelWrapper(object):
                 for im in page['ims']:
                     if im['is_user_deleted']:
                         continue
-                    im['name'] = im['id']
+                    # Set the channel name to the user being directly messaged
+                    # for easier reverse lookups. Note: `user` here is the
+                    # user_id.
+                    im['name'] = im['user']
                     self._add_channel(im)
             self._initialised = True
 
@@ -261,8 +264,9 @@ class ChannelWrapper(object):
 
     def _on_im_created(self, evt):
         chan = evt['channel']
-
-        chan['name'] = chan['id']
+        # Set the channel name to the user being directly messaged for easier
+        # reverse lookups. Note: `user` here is the user_id.
+        chan['name'] = evt['user']
         self._add_channel(chan)
 
     def _on_member_joined_channel(self, evt):

--- a/uqcsbot/base.py
+++ b/uqcsbot/base.py
@@ -150,7 +150,10 @@ class UQCSBot(object):
         Wrap a function to run it asynchronously if it's not already a coroutine function
         """
         if not asyncio.iscoroutinefunction(fn):
+            fn_doc = fn.__doc__
             fn = partial(self.run_async, fn)
+            # Ensure the function's docstring is copied over.
+            fn.__doc__ = fn_doc
         return fn
 
     async def run_async(self, fn, *args, **kwargs):

--- a/uqcsbot/scripts/acronym.py
+++ b/uqcsbot/scripts/acronym.py
@@ -18,6 +18,9 @@ async def get_acronyms(word: str) -> (str, List[str]):
 
 @bot.on_command("acro")
 async def handle_acronym(command: Command):
+    '''
+    `!acro <TEXT>` - Finds an acronym for the given text.
+    '''
     if not command.has_arg():
         return
 

--- a/uqcsbot/scripts/caesar.py
+++ b/uqcsbot/scripts/caesar.py
@@ -6,6 +6,10 @@ CAESAR_REGEX = re.compile('!caesar(|-?\d+) (.+)')
 
 @bot.on('message')
 def handle_caesar(message: dict):
+    '''
+    `!caesar[N] <TEXT>` - Performs caesar shift with a left shift of N on given
+    text. If unspecified, will shift by 47.
+    '''
     text = message.get("text")
     if message.get("subtype") == "bot_message" or text is None:
         return

--- a/uqcsbot/scripts/cat.py
+++ b/uqcsbot/scripts/cat.py
@@ -3,6 +3,9 @@ from uqcsbot import bot, Command
 
 @bot.on_command("cat")
 def handle_cat(command: Command):
+    '''
+    `!cat` - Displays the moss cat. Brings torture to 2310 students.
+    '''
     cat = "```\n" + \
           "         __..--''``\\--....___   _..,_\n" + \
           "     _.-'    .-/\";  `        ``<._  ``-+'~=.\n" + \

--- a/uqcsbot/scripts/cookbook.py
+++ b/uqcsbot/scripts/cookbook.py
@@ -3,4 +3,7 @@ from uqcsbot import bot, Command
 
 @bot.on_command("cookbook")
 def handle_cookbook(command: Command):
+    '''
+    `!cookbook` - Returns the URL of the UQCS student-compiled cookbook (pdf).
+    '''
     bot.post_message(command.channel, "https://github.com/UQComputingSociety/cookbook")

--- a/uqcsbot/scripts/dog.py
+++ b/uqcsbot/scripts/dog.py
@@ -3,6 +3,9 @@ from uqcsbot import bot, Command
 
 @bot.on_command("dog")
 def handle_dog(command: Command):
+    '''
+    `!dog` - Like !cat, but for dog people.
+    '''
     dog = "```\n" + \
           "                                __\n" + \
           "         ,                    ,\" .\`--o\n" + \

--- a/uqcsbot/scripts/echo.py
+++ b/uqcsbot/scripts/echo.py
@@ -3,5 +3,10 @@ from uqcsbot import bot, Command
 
 @bot.on_command("echo")
 def handle_echo(command: Command):
+    '''
+    `!echo [TEXT]` - Echos back the given text.
+    '''
     if command.has_arg():
         bot.post_message(command.channel, command.arg)
+    else:
+        bot.post_message(command.channel, "ECHO!")

--- a/uqcsbot/scripts/ecp.py
+++ b/uqcsbot/scripts/ecp.py
@@ -8,6 +8,11 @@ COURSE_URL = 'https://my.uq.edu.au/programs-courses/course.html?course_code='
 
 @bot.on_command('ecp')
 async def handle_ecp(command: Command):
+    '''
+    `!ecp [COURSE CODE]` - Returns the link to the latest ECP for the given
+    course code. If unspecified, will attempt to find the ECP for the channel
+    the command was called from.
+    '''
     channel = command.channel
     course_name = channel.name if not command.has_arg() else command.arg
     http_response = await bot.run_async(requests.get, f"{COURSE_URL}{quote(course_name)}")

--- a/uqcsbot/scripts/events.py
+++ b/uqcsbot/scripts/events.py
@@ -88,6 +88,11 @@ class Event(object):
 
 @bot.on_command('events')
 async def handle_events(command: Command):
+    '''
+    `!events [full|all|NUM EVENTS|<NUM WEEKS> weeks]` - Lists all the UQCS
+    events that are scheduled to occur within the given filter. If unspecified,
+    will return the next 2 weeks of events.
+    '''
     event_filter = EventFilter.from_command(command)
     if not event_filter.is_valid:
         bot.post_message(command.channel, "Invalid events filter.")

--- a/uqcsbot/scripts/help.py
+++ b/uqcsbot/scripts/help.py
@@ -7,11 +7,11 @@ def sanitize_doc(doc):
     '''
     return ' '.join([line.strip() for line in doc.split('\n')])
 
-def is_valid_doc(doc):
+def is_valid_helper_doc(doc):
     '''
-    Returns true if a helper docstring was found. Ignores docstrings that have
-    specified they are not a helper docstring by including '@no_help' within
-    them.
+    Returns true if the given docstring is a valid helper docstring. Ignores
+    docstrings that have specified they are not a helper docstring by including
+    '@no_help' within them.
     '''
     return doc != None and '@no_help' not in doc
 
@@ -19,12 +19,12 @@ def get_helper_docs():
     '''
     Returns a generator of all the bot's command names and their associated
     helper docstrings. Will filter out any commands that do not have valid
-    docstrings (see: is_valid_doc).
+    docstrings (see: is_valid_helper_doc).
     '''
     return ((command_name, fn.__doc__)
             for command_name, functions in bot.command_registry.items()
             for fn in functions
-            if is_valid_doc(fn.__doc__))
+            if is_valid_helper_doc(fn.__doc__))
 
 @bot.on_command('help')
 async def handle_help(command: Command):

--- a/uqcsbot/scripts/help.py
+++ b/uqcsbot/scripts/help.py
@@ -1,5 +1,4 @@
 from uqcsbot import bot, Command
-from functools import partial
 
 def sanitize_doc(doc):
     '''
@@ -10,16 +9,11 @@ def sanitize_doc(doc):
 
 def is_valid_doc(doc):
     '''
-    Returns true if a doc was found and it was not the doc for partial, else
-    returns false.
-
-    The check for `partial` doc equality is necessary as some commands are
-    declared as async, which gets wrapped in a `partial` by uqcsbot. If the
-    async commands possess no docstring of their own, they will by default adopt
-    the `partial` docstring instead of None (which is the case for non-async
-    commands with no docstring).
+    Returns true if a helper docstring was found. Ignores docstrings that have
+    specified they are not a helper docstring by including '@no_help' within
+    them.
     '''
-    return doc != None and doc != partial.__doc__
+    return doc != None and '@no_help' not in doc
 
 def get_helper_docs():
     '''
@@ -35,7 +29,8 @@ def get_helper_docs():
 @bot.on_command('help')
 async def handle_help(command: Command):
     """
-    TODO(mcdermottm): write this command docstring, and every other docstring
+    `!help [COMMAND]` - Display the helper docstring for the given command. If
+    unspecified, will return the helper docstrings for all commands.
     """
     helper_docs = [sanitize_doc(helper_doc)
                    for command_name, helper_doc in get_helper_docs()

--- a/uqcsbot/scripts/help.py
+++ b/uqcsbot/scripts/help.py
@@ -18,8 +18,8 @@ def is_valid_helper_doc(doc):
 def get_helper_docs():
     '''
     Returns a generator of all the bot's command names and their associated
-    helper docstrings. Will filter out any commands that do not have valid
-    docstrings (see: is_valid_helper_doc).
+    helper docstrings. Will filter out any commands that do not have a valid
+    helper docstring (see: is_valid_helper_doc).
     '''
     return ((command_name, fn.__doc__)
             for command_name, functions in bot.command_registry.items()

--- a/uqcsbot/scripts/help.py
+++ b/uqcsbot/scripts/help.py
@@ -1,0 +1,48 @@
+from uqcsbot import bot, Command
+from functools import partial
+
+def sanitize_doc(doc):
+    '''
+    Returns the doc in sanitized form. This involves removing any newlines and
+    whitespace blocks at the start or end of lines.
+    '''
+    return ' '.join([line.strip() for line in doc.split('\n')])
+
+def is_valid_doc(doc):
+    '''
+    Returns true if a doc was found and it was not the doc for partial, else
+    returns false.
+
+    The check for `partial` doc equality is necessary as some commands are
+    declared as async, which gets wrapped in a `partial` by uqcsbot. If the
+    async commands possess no docstring of their own, they will by default adopt
+    the `partial` docstring instead of None (which is the case for non-async
+    commands with no docstring).
+    '''
+    return doc != None and doc != partial.__doc__
+
+def get_helper_docs():
+    '''
+    Returns a generator of all the bot's command names and their associated
+    helper docstrings. Will filter out any commands that do not have valid
+    docstrings (see: is_valid_doc).
+    '''
+    return ((command_name, fn.__doc__)
+            for command_name, functions in bot.command_registry.items()
+            for fn in functions
+            if is_valid_doc(fn.__doc__))
+
+@bot.on_command('help')
+async def handle_help(command: Command):
+    """
+    TODO(mcdermottm): write this command docstring, and every other docstring
+    """
+    helper_docs = [sanitize_doc(helper_doc)
+                   for command_name, helper_doc in get_helper_docs()
+                   if not command.has_arg() or command.arg == command_name]
+
+    user_direct_channel = bot.channels.get(command.user_id, None)
+    if len(helper_docs) == 0:
+        bot.post_message(user_direct_channel, f'Could not find any helper docstrings.')
+    else:
+        bot.post_message(user_direct_channel, '>>>' + '\n'.join(helper_docs))

--- a/uqcsbot/scripts/pastexams.py
+++ b/uqcsbot/scripts/pastexams.py
@@ -6,15 +6,11 @@ import requests
 
 @bot.on_command('pastexams')
 async def handle_pastexams(command: Command):
-    """
-    Posts a list of past exams for a a course given its course code. Defaults to the channels name if no course
-    code is supplied.
-
-    Usage:
-    !pastexams CSSE2310
-    or if in a course channel:
-    !pastexams
-    """
+    '''
+    `!pastexams [COURSE CODE]` - Retrieves past exams for a given course code.
+    If unspecified, will attempt to find the ECP for the channel the command was
+    called from.
+    '''
     course_code = command.arg if command.has_arg() else command.channel.name
     past_exams = await get_past_exams(course_code)
 

--- a/uqcsbot/scripts/radar.py
+++ b/uqcsbot/scripts/radar.py
@@ -4,5 +4,8 @@ from time import time
 
 @bot.on_command("radar")
 def handle_radar(command: Command):
+    '''
+    `!radar` - Returns the latest BOM radar image for Brisbane.
+    '''
     time_in_ms = int(round(time() * 1000))
     bot.post_message(command.channel, f'https://bom.lambda.tools/?location=brisbane&_cache={time_in_ms}')

--- a/uqcsbot/scripts/repo.py
+++ b/uqcsbot/scripts/repo.py
@@ -3,4 +3,7 @@ from uqcsbot import bot, Command
 
 @bot.on_command("repo")
 def handle_repo(command: Command):
+    '''
+    `!repo` - Returns the url for the uqcsbot repo.
+    '''
     bot.post_message(command.channel, "https://github.com/UQComputingSociety/uqcsbot")

--- a/uqcsbot/scripts/spider.py
+++ b/uqcsbot/scripts/spider.py
@@ -3,4 +3,7 @@ from uqcsbot import bot, Command
 
 @bot.on_command("spider")
 def handle_spider(command: Command):
+    '''
+    `!spider` - Displays the spider shrug.
+    '''
     bot.post_message(command.channel, "//\\; ;/\\\\")

--- a/uqcsbot/scripts/voteythumbs.py
+++ b/uqcsbot/scripts/voteythumbs.py
@@ -24,6 +24,10 @@ def strip(message: str, prefixes=VOTEYTHUMBS_STRIP_PREFIXES):
 
 @bot.on('message')
 async def voteythumbs(evt: dict):
+    '''
+    `!voteythumbs <TOPIC>` - Starts a :thumbsup: :thumbsdown: vote on the given
+    topic. If unspecified, will not set a topic.
+    '''
     if "!voteythumbs" not in evt.get("text", ""):
         return
     evt["text"] = strip(evt["text"])

--- a/uqcsbot/scripts/wakie.py
+++ b/uqcsbot/scripts/wakie.py
@@ -6,6 +6,12 @@ REACTS = ['waiting', 'apple_waiting', 'waiting_droid', 'keen', 'fiestaparrot']
 
 @bot.on_schedule('cron', hour=17, timezone='Australia/Brisbane')
 async def wakie():
+    '''
+    'Wakes' up two UQCS members by pinging them on general and asking what
+    they're working on.
+
+    @no_help
+    '''
     channel = bot.channels.get("general")
     victims = sample(channel.members, 2)
     lines = [f'Hey <@{v}>! Tell us about something cool you are working on!' for v in victims]

--- a/uqcsbot/scripts/wavie.py
+++ b/uqcsbot/scripts/wavie.py
@@ -8,7 +8,9 @@ logger = logging.getLogger(__name__)
 @bot.on('message')
 def wave(evt):
     """
-    Wave reacts to "person joined/left this channel"
+    :wave: reacts to "person joined/left this channel"
+
+    @no_help
     """
     if evt.get('subtype') not in ['channel_join', 'channel_leave']:
         return

--- a/uqcsbot/scripts/welcome.py
+++ b/uqcsbot/scripts/welcome.py
@@ -18,17 +18,19 @@ WELCOME_MESSAGES = [    # Welcome messages sent to new members
 async def welcome(evt: dict):
     """
     Welcomes new users to UQCS Slack and checks for member milestones
+
+    @no_help
     """
     chan = bot.channels.get(evt.get('channel'))
     if chan is None or chan.name != "announcements":
         return
-    
+
     announcements = chan
     general = bot.channels.get("general")
-    
+
     user_info = await bot.run_async(bot.api.users.info, user=evt.get("user"))
     display_name = user_info.get("user", {}).get("profile", {}).get("display_name")
-    
+
     if display_name:
         await bot.run_async(bot.post_message, general, f"Welcome, {display_name}")
 

--- a/uqcsbot/scripts/wiki.py
+++ b/uqcsbot/scripts/wiki.py
@@ -5,6 +5,9 @@ import json
 
 @bot.on_command("wiki")
 async def handle_wiki(command: Command):
+    '''
+    `!wiki <TOPIC>` - Returns a snippet of text from a relevent wikipedia entry.
+    '''
     search_query = command.arg
     api_url = f"https://en.wikipedia.org/w/api.php?action=opensearch&format=json&limit=2"
 

--- a/uqcsbot/scripts/wolfram.py
+++ b/uqcsbot/scripts/wolfram.py
@@ -24,10 +24,13 @@ def get_subpods(pods: list) -> Iterable[Tuple[str, dict]]:
 
 @bot.on_command('wolfram')
 async def handle_wolfram(command: Command):
-    """
-    Determines whether to use the full version or the short version. The full version is used if the --full
-    argument is supplied before or after the search query. See wolfram_full and wolfram_normal for the differences.
-    """
+    '''
+    `!wolfram [--full] <QUERY>` - Returns the wolfram response for the given
+    query. If `--full` is specified, will return the full reponse.
+    '''
+    # Determines whether to use the full version or the short version. The full
+    # version is used if the --full. argument is supplied before or after the
+    # search query. See wolfram_full and wolfram_normal for the differences.
     if command.has_arg():
         cmd = command.arg.strip()
         # Doing it specific to the start and end just in case someone has --full inside their query for whatever reason


### PR DESCRIPTION
Brings back the !help functionality from jsbot. This command allows users to discover the helper docstrings for all uqcsbot's commands-- and additionally allows specified querying for a certain command's docstring.

Functional demonstration:
![image](https://user-images.githubusercontent.com/10495244/37411509-af395b0c-27ee-11e8-8b0e-e8e08a4c08d8.png)

In addition, this PR added the ability for commands to know which user called them. It also changed how direct channels were stored by setting the previously redundant name to be the direct message user's id. This allows for much easier reverse lookup of calling user's direct message channel.

As always, feedback and reviews are much appreciated :^)

Fixes #245.