### PR TITLE
Async Rate Limiting

### DIFF
--- a/uqcsbot/api.py
+++ b/uqcsbot/api.py
@@ -91,9 +91,9 @@ class APIMethodProxy(object):
             return result
         if self._is_async:
             loop = asyncio.get_event_loop()
-            loop.run_in_executor(None, call_inner)
+            return loop.run_in_executor(None, call_inner)
         else:
-            return call_inner
+            return call_inner()
 
     def paginate(self, **kwargs) -> Paginator:
         """

--- a/uqcsbot/api.py
+++ b/uqcsbot/api.py
@@ -89,7 +89,7 @@ class APIMethodProxy(object):
             else:
                 result = {'ok': False, 'error': 'Reached max rate-limiting retries'}
             return result
-        if self._is_async:
+        if self._async:
             loop = asyncio.get_event_loop()
             return loop.run_in_executor(None, call_inner)
         else:

--- a/uqcsbot/api.py
+++ b/uqcsbot/api.py
@@ -68,6 +68,8 @@ class APIMethodProxy(object):
         If the APIMethodProxy was constructed with `is_async=True` runs the
         request asynchronously via:
             asyncio.get_event_loop().run_in_executor(None, req)
+
+        Attempts to retry the API call if rate-limited.
         """
         fn = partial(
             self._client.api_call,

--- a/uqcsbot/api.py
+++ b/uqcsbot/api.py
@@ -80,7 +80,7 @@ class APIMethodProxy(object):
         while retry_count < 5:
             if self._async:
                 loop = asyncio.get_event_loop()
-                result = loop.run_in_executor(None, fn)
+                result = await loop.run_in_executor(None, fn)
             else:
                 result = fn()
             if not result['ok'] and result['error'] == 'ratelimited':


### PR DESCRIPTION
Uses #276 as a base, but adds more sophisticated async logic.

We could totally cheat and just use the sync method in a call to `loop.run_in_executor` but this should theoretically play nicer with our event loop?

If we'd prefer less duplication over incredibly slight perf benefits, I'll rewrite.