### PR TITLE
Fixed !events

### DIFF
--- a/uqcsbot/scripts/events.py
+++ b/uqcsbot/scripts/events.py
@@ -40,8 +40,9 @@ class EventFilter(object):
         if self._weeks is not None:
             end_time = start_time + timedelta(weeks=self._weeks)
             return [e for e in events if e.start < end_time]
-        if self._cap is not None:
+        elif self._cap is not None:
             return events[:self._cap]
+        return events
 
     def get_header(self):
         if self._full:
@@ -72,10 +73,10 @@ class Event(object):
         # ical 'dt' properties are parsed as a 'DDD' (datetime, date, duration)
         # type. The below code converts a date to a datetime, where time is set
         # to midnight.
-        if isinstance(start, date):
+        if isinstance(start, date) and not isinstance(start, datetime):
             start = datetime.combine(start, datetime.min.time()).astimezone(utc)
-        if isinstance(end, date):
-            end = datetime.combine(end, datetime.min.time()).astimezone(utc)
+        if isinstance(end, date) and not isinstance(end, datetime):
+            end = datetime.combine(end, datetime.max.time()).astimezone(utc)
         location = cal_event.get('location', 'TBA')
         summary = cal_event.get('summary')
         return cls(start, end, location, summary)

--- a/uqcsbot/scripts/events.py
+++ b/uqcsbot/scripts/events.py
@@ -2,7 +2,7 @@ from typing import List
 from uqcsbot import bot, Command
 from icalendar import Calendar, vText
 import requests
-from datetime import datetime, timedelta
+from datetime import date, datetime, timedelta
 from pytz import timezone, utc
 import re
 
@@ -69,6 +69,13 @@ class Event(object):
     def from_cal_event(cls, cal_event):
         start = cal_event.get('dtstart').dt
         end = cal_event.get('dtend').dt
+        # ical 'dt' properties are parsed as a 'DDD' (datetime, date, duration)
+        # type. The below code converts a date to a datetime, where time is set
+        # to midnight.
+        if isinstance(start, date):
+            start = datetime.combine(start, datetime.min.time()).astimezone(utc)
+        if isinstance(end, date):
+            end = datetime.combine(end, datetime.min.time()).astimezone(utc)
         location = cal_event.get('location', 'TBA')
         summary = cal_event.get('summary')
         return cls(start, end, location, summary)


### PR DESCRIPTION
I found two bugs:
1) `.dt` can return `date` objects, which will error later on when we tried to compare them to `datetime` objects
2) `filter_events` did not have a return path for when `full` was given, so it was setting `events = None`

I fixed these by adding datetime conversion as well as adding in a default return path for cases such as `full`.

Fixes #289.