### PR TITLE
Removed async as a core part of the framework

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -47,12 +47,6 @@ class MockUQCSBot(UQCSBot):
         self.test_posted_messages = []  # A list of posted messages for unit testing
         self.channels = {}  # Allows get to fail. TODO mock channel object
 
-    def on_command(self, command_name: str):
-        def decorator(fn):
-            self._command_registry[command_name].append(fn)
-            return fn
-        return decorator
-
     def test_handle_event(self, message):
         command = Command.from_message(self, message)
         if command is None:

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -2,7 +2,6 @@
 Configuration for Pytest
 """
 import pytest
-import asyncio
 from typing import List, Union, Optional, Callable
 
 import uqcsbot as uqcsbot_module
@@ -37,9 +36,6 @@ class UnmatchedHandleException(Exception):
     pass
 
 class MockUQCSBot(UQCSBot):
-    """
-    Overwrites a bunch of async stuff to make tests work.
-    """
     test_posted_messages: List[PostedMessage] = None
 
     def __init__(self, logger=None):

--- a/uqcsbot/api.py
+++ b/uqcsbot/api.py
@@ -3,14 +3,14 @@ import time
 from slackclient import SlackClient
 import asyncio
 import threading
-from typing import TYPE_CHECKING, List, Iterable, AsyncIterable, AsyncGenerator, Generator, Any, Union, TypeVar, Awaitable
+from typing import TYPE_CHECKING, List, Iterable, Optional, Generator, Any, Union, TypeVar, Dict
 if TYPE_CHECKING:
     from .base import UQCSBot
 
 T = TypeVar('T')
 
 
-class Paginator(Iterable[dict], AsyncIterable[dict]):
+class Paginator(Iterable[dict]):
     """
     Provides synchronous and asynchronous iterators over the pages of responses
     from a cursor-based paginated Slack
@@ -35,32 +35,16 @@ class Paginator(Iterable[dict], AsyncIterable[dict]):
     def __iter__(self):
         return self._gen()
 
-    async def _agen(self):
-        loop = asyncio.get_event_loop()
-        kwargs = self._kwargs.copy()
-        request_fn = partial(self._client.api_call, self._method, **kwargs)
-        while True:
-            page = await loop.run_in_executor(None, request_fn)
-            yield page
-            cursor = page.get('response_metadata', {}).get('next_cursor')
-            if not cursor:
-                break
-            kwargs["cursor"] = cursor
-
-    def __aiter__(self) -> AsyncGenerator[dict, Any]:
-        return self._agen()
-
 
 class APIMethodProxy(object):
     """
     Helper class used to implement APIWrapper
     """
-    def __init__(self, client: SlackClient, method: str, is_async: bool = False):
+    def __init__(self, client: SlackClient, method: str) -> None:
         self._client = client
         self._method = method
-        self._async = is_async
 
-    def __call__(self, **kwargs) -> Union[dict, Awaitable[dict]]:
+    def __call__(self, **kwargs) -> dict:
         """
         Perform the relevant API request. Equivalent to SlackClient.api_call
         except the `method` argument is filled in.
@@ -76,24 +60,18 @@ class APIMethodProxy(object):
             self._method,
             **kwargs
         )
-        def call_inner():
-            retry_count = 0
-            while retry_count < 5:
-                result = fn()
-                if not result['ok'] and result['error'] == 'ratelimited':
-                    retry_after_secs = int(result['headers']['Retry-After'])
-                    time.sleep(retry_after_secs)
-                    retry_count += 1
-                else:
-                    break
+        retry_count = 0
+        while retry_count < 5:
+            result = fn()
+            if not result['ok'] and result['error'] == 'ratelimited':
+                retry_after_secs = int(result['headers']['Retry-After'])
+                time.sleep(retry_after_secs)
+                retry_count += 1
             else:
-                result = {'ok': False, 'error': 'Reached max rate-limiting retries'}
-            return result
-        if self._async:
-            loop = asyncio.get_event_loop()
-            return loop.run_in_executor(None, call_inner)
+                break
         else:
-            return call_inner()
+            result = {'ok': False, 'error': 'Reached max rate-limiting retries'}
+        return result
 
     def paginate(self, **kwargs) -> Paginator:
         """
@@ -120,7 +98,6 @@ class APIMethodProxy(object):
         return APIMethodProxy(
             client=self._client,
             method=f'{self._method}.{item}',
-            is_async=self._async,
         )
 
 
@@ -139,22 +116,17 @@ class APIWrapper(object):
         > async_api = api(is_async=True)
         > await async_api.chat.postMessage(channel="general", text="message")
     """
-    def __init__(self, client: SlackClient, is_async: bool = False):
+    def __init__(self, client: SlackClient) -> None:
         self._client = client
-        self._async = is_async
 
     def __getattr__(self, item) -> APIMethodProxy:
         return APIMethodProxy(
             client=self._client,
             method=item,
-            is_async=self._async
         )
 
-    def __call__(self, **kwargs) -> 'APIWrapper':
-        """
-        On call, reconfigure the API Wrapper
-        """
-        return type(self)(self._client, **kwargs)
+    def __repr__(self) -> str:
+        return f"<APIWrapper of {repr(client)}>"
 
 
 class Channel(object):
@@ -169,11 +141,11 @@ class Channel(object):
         is_private: bool = False,
         is_archived: bool = False,
         previous_names: List[str] = None
-    ):
+    ) -> None:
         self._bot = bot
         self.id = channel_id
         self.name = name
-        self._member_ids = None
+        self._member_ids = None  # type: Optional[List[str]]
         self.is_group = is_group
         self.is_im = is_im
         self.is_public = is_public
@@ -186,10 +158,10 @@ class Channel(object):
         if self._member_ids is not None:
             return self._member_ids
         self._bot.logger.debug(f"Loading members for {self.name}<{self.id}>")
-        members = []
+        members_ls = []  # type: List[str]
         for page in self._bot.api.conversations.members.paginate(channel=self.id):
-            members += page.get("members", [])
-        self._member_ids = members
+            members_ls += page.get("members", [])
+        self._member_ids = members_ls
         return self._member_ids
 
     def update_members(self) -> List[str]:
@@ -198,11 +170,11 @@ class Channel(object):
 
 
 class ChannelWrapper(object):
-    def __init__(self, bot: 'UQCSBot'):
+    def __init__(self, bot: 'UQCSBot') -> None:
         self._bot = bot
         self._initialised = False
-        self._channels_by_id = {}
-        self._channels_by_name = {}
+        self._channels_by_id = {}  # type: Dict[str, dict]
+        self._channels_by_name = {}  # type: Dict[str, dict]
         self._lock = threading.RLock()
         self._bind_handlers()
 

--- a/uqcsbot/base.py
+++ b/uqcsbot/base.py
@@ -8,15 +8,15 @@ import threading
 import logging
 import time
 from contextlib import contextmanager
-from typing import Callable, Optional, Union, TypeVar, DefaultDict
-from apscheduler.schedulers.asyncio import AsyncIOScheduler
+from typing import Callable, Optional, Union, TypeVar, DefaultDict, Type
+from apscheduler.schedulers.background import BackgroundScheduler
 
 
-T = TypeVar('T')
+CmdT = TypeVar('CmdT', bound='Command')
 
 
 class Command(object):
-    def __init__(self, command_name: str, arg: Optional[str], channel: Channel, message: dict):
+    def __init__(self, command_name: str, arg: Optional[str], channel: Channel, message: dict) -> None:
         self.command_name = command_name
         self.channel = channel
         self.arg = arg
@@ -26,7 +26,7 @@ class Command(object):
         return self.arg is not None
 
     @classmethod
-    def from_message(cls: T, message: dict) -> Optional[T]:
+    def from_message(cls: Type[CmdT], message: dict) -> Optional[CmdT]:
         text = message.get("text", '')
         if message.get("subtype") == "bot_message" or not text.startswith("!"):
             return None
@@ -37,6 +37,10 @@ class Command(object):
             arg=None if not arg else arg[0],
             message=message
         )
+
+    @property
+    def user_id(self):
+        return self.message['user']
 
 
 CommandHandler = Callable[[Command], None]
@@ -53,32 +57,23 @@ def protected_property(prop_name, attr_name):
 underscored_getter = lambda s: protected_property(s, '_' + s)
 
 
-def async_worker(loop):
-    asyncio.set_event_loop(loop)
-    loop.run_forever()
-
-
 class UQCSBot(object):
     api_token: Optional[str] = underscored_getter("api_token")
     client: Optional[SlackClient] = underscored_getter("client")
     verification_token: Optional[str] = underscored_getter("verification_token")
-    evt_loop: Optional[asyncio.AbstractEventLoop] = underscored_getter("evt_loop")
     executor: Optional[concurrent.futures.ThreadPoolExecutor] = underscored_getter("executor")
-    scheduler: Optional[AsyncIOScheduler] = underscored_getter("scheduler")
+    scheduler: Optional[BackgroundScheduler] = underscored_getter("scheduler")
     command_registry: Optional[DefaultDict[str, list]] = underscored_getter("command_registry")
 
     def __init__(self, logger=None):
         self._api_token = None
         self._client = None
         self._verification_token = None
-        self._evt_loop = asyncio.new_event_loop()
         self._executor = concurrent.futures.ThreadPoolExecutor()
-        self._evt_loop.set_default_executor(self._executor)
         self.logger = logger or logging.getLogger("uqcsbot")
-        self._evt_loop.set_debug(self.logger.isEnabledFor(logging.DEBUG))
         self._handlers = collections.defaultdict(list)
         self._command_registry = collections.defaultdict(list)
-        self._scheduler = AsyncIOScheduler(event_loop=self._evt_loop)
+        self._scheduler = BackgroundScheduler()
 
         self.register_handler('message', self._handle_command)
         self.register_handler('hello', self._handle_hello)
@@ -96,18 +91,19 @@ class UQCSBot(object):
             self.logger.debug(f"Goodbye event has unexpected extras: {evt}")
         self.logger.info(f"Server is about to disconnect")
 
-    async def _handle_command(self, message: dict) -> None:
-        command = Command.from_message(message)
+    def _handle_command(self, message: dict) -> None:
+        command = Command.from_message(self, message)
         if command is None:
             return
-        await asyncio.gather(*[
-            self._await_error(cmd(command))
-            for cmd in self.command_registry[command.command_name]
-        ])
+        for handler in self.command_registry[command.command_name]:
+            self.executor.submit(
+                self._execute_catching_error,
+                handler,
+                command,
+            )
 
     def on_command(self, command_name: str):
         def decorator(fn):
-            fn = self._wrap_async(fn)
             self.command_registry[command_name].append(fn)
             return fn
         return decorator
@@ -125,7 +121,6 @@ class UQCSBot(object):
             message_type = ""
         if not callable(handler_fn):
             raise TypeError(f"Handler function {handler_fn} must be callable")
-        handler_fn = self._wrap_async(handler_fn)
         self._handlers[message_type].append(handler_fn)
         return handler_fn
 
@@ -138,57 +133,35 @@ class UQCSBot(object):
     def api(self):
         return APIWrapper(self.client)
 
-    @property
-    def as_async(self):
-        return AsyncBotWrapper(self)
-
     def post_message(self, channel: Union[Channel, str], text: str, **kwargs):
         channel_id = channel if isinstance(channel, str) else channel.id
         return self.api.chat.postMessage(channel=channel_id, text=text, **kwargs)
 
-    def _wrap_async(self, fn):
+    def get_event_loop(self) -> asyncio.AbstractEventLoop:
         """
-        Wrap a function to run it asynchronously if it's not already a coroutine function
-        """
-        if not asyncio.iscoroutinefunction(fn):
-            fn_doc = fn.__doc__
-            fn = partial(self.run_async, fn)
-            # Ensure the function's docstring is copied over.
-            fn.__doc__ = fn_doc
-        return fn
+        Provides an AbstractEventLoop that works in the current command context.
 
-    async def run_async(self, fn, *args, **kwargs):
+        This is the extent of our asyncio support.
         """
-        Private:
-
-        Runs a synchronous function in the bot's async executor, tracking it with
-        asyncio.
-        """
-        return await self._evt_loop.run_in_executor(self._executor, partial(fn, *args, **kwargs))
+        policy = asyncio.get_event_loop_policy()
+        if policy._local._loop is None:  # type: ignore
+            policy.set_event_loop(policy.new_event_loop())
+        return policy.get_event_loop()
 
     @contextmanager
-    def _async_context(self):
-        async_thread = threading.Thread(target=async_worker, args=(self._evt_loop,))
-        async_thread.start()
+    def _execution_context(self):
         self._scheduler.start()
-        # Windows bugfix - cancelling queues requires a task being queued
-        fix_future = asyncio.run_coroutine_threadsafe(asyncio.sleep(1000), self._evt_loop)
         try:
             yield
-            fix_future.cancel()
         except:
             self.logger.exception("An error occurred, exiting")
             self._scheduler.shutdown()
             self._executor.shutdown()
-            fix_future.cancel()
-            self._evt_loop.stop()
-            async_thread.join()
-            self._evt_loop.close()
             raise
 
-    async def _await_error(self, awaitable):
+    def _execute_catching_error(self, handler, evt):
         try:
-            return (await awaitable)
+            return handler(evt)
         except Exception:
             self.logger.exception('Error in handler')
             return None
@@ -198,10 +171,11 @@ class UQCSBot(object):
         if "type" not in event:
             self.logger.error(f"No type in message: {event}")
         handlers = self._handlers[event['type']] + self._handlers['']
-        awaitables = [
-            asyncio.run_coroutine_threadsafe(
-                self._await_error(handler(event)),
-                loop=self.evt_loop
+        return [
+            self.executor.submit(
+                self._execute_catching_error,
+                handler,
+                event,
             )
             for handler in handlers
         ]
@@ -212,14 +186,11 @@ class UQCSBot(object):
 
         api_token: Slack API token
         verification_token: Events API verification token
-        evt_loop: asyncio event loop - if not provided uses default policy
-        executor:
-            Asynchronous executor - if not provided creates a ThreadPoolExecutor
         """
         self._api_token = api_token
         self._client = SlackClient(api_token)
         self._verification_token = verification_token
-        with self._async_context():
+        with self._execution_context():
             # Initialise channels at start so we don't have to block
             self.channels._initialise()
 
@@ -244,7 +215,7 @@ class UQCSBot(object):
                 print(kwargs)
 
         self.api_call = cli_api_call
-        with self._async_context():
+        with self._execution_context():
             while True:
                 response = input("> ")
                 self._run_handlers({
@@ -253,27 +224,6 @@ class UQCSBot(object):
                     "subtype": "user",
                     "type": "message"
                 })
-
-
-class AsyncBotWrapper(object):
-    bot: UQCSBot
-
-    def __init__(self, bot: UQCSBot):
-        self.bot = bot
-
-    def __getattr__(self, name):
-        attr = getattr(self.bot, name)
-        if not callable(attr) or asyncio.iscoroutinefunction(attr):
-            return attr
-        return partial(bot.run_async, attr)
-
-    @property
-    def as_async(self):
-        return self
-
-    @property
-    def api(self):
-        return self.bot.api(is_async=True)
 
 
 bot = UQCSBot()

--- a/uqcsbot/scripts/acronym.py
+++ b/uqcsbot/scripts/acronym.py
@@ -3,21 +3,22 @@ from requests import get
 from requests.utils import quote
 from bs4 import BeautifulSoup
 from typing import List
+from functools import partial
 import asyncio
 
 ACRONYM_LIMIT = 5
 BASE_URL = "http://acronyms.thefreedictionary.com"
 
 
-async def get_acronyms(word: str) -> (str, List[str]):
-    http_response = await bot.run_async(get, f"{BASE_URL}/{quote(word)}")
+async def get_acronyms(loop, word: str) -> (str, List[str]):
+    http_response = await loop.run_in_executor(None, partial(get, f"{BASE_URL}/{quote(word)}"))
     html = BeautifulSoup(http_response.content, 'html.parser')
     acronym_tds = html.find_all("td", class_="acr")
     return word, [td.find_next_sibling("td").text for td in acronym_tds]
 
 
 @bot.on_command("acro")
-async def handle_acronym(command: Command):
+def handle_acronym(command: Command):
     '''
     `!acro <TEXT>` - Finds an acronym for the given text.
     '''
@@ -30,15 +31,16 @@ async def handle_acronym(command: Command):
     if len(words) == 1:
         word = words[0]
         if word.lower() in [":horse:", "horse"]:
-            await bot.as_async.post_message(command.channel, ">:taco:")
+            bot.post_message(command.channel, ">:taco:")
             return
         elif word.lower() in [":rachel:", "rachel"]:
-            await bot.as_async.post_message(command.channel, ">:older_woman:")
+            bot.post_message(command.channel, ">:older_woman:")
             return
 
-    acronym_futures = [get_acronyms(word) for word in words[:ACRONYM_LIMIT]]
+    loop = bot.get_event_loop()
+    acronym_futures = [get_acronyms(loop, word) for word in words[:ACRONYM_LIMIT]]
     response = ""
-    for word, acronyms in await asyncio.gather(*acronym_futures):
+    for word, acronyms in loop.run_until_complete(asyncio.gather(*acronym_futures)):
         if acronyms:
             acronym = acronyms[0]
             response += f">{word.upper()}: {acronym}\r\n"
@@ -48,4 +50,4 @@ async def handle_acronym(command: Command):
     if len(words) > ACRONYM_LIMIT:
         response += f">I am limited to {ACRONYM_LIMIT} acronyms at once"
 
-    await bot.as_async.post_message(command.channel, response)
+    bot.post_message(command.channel, response)

--- a/uqcsbot/scripts/define.py
+++ b/uqcsbot/scripts/define.py
@@ -5,21 +5,21 @@ import json
 API_URL = "http://api.pearson.com/v2/dictionaries/laad3/entries?limit=1"
 
 @bot.on_command("define")
-async def define(command: Command):
+def define(command: Command):
     '''
     `!define <TEXT>` - Gets the dictionary definition of TEXT
     '''
     query = command.arg
     # Fun Fact: Empty searches return the definition of adagio (a piece of music to be played or sung slowly)
     if not command.has_arg():
-        await bot.as_async.post_message(command.channel, "Please specify a word")
+        bot.post_message(command.channel, "Please specify a word")
         return
 
-    http_response = await bot.run_async(requests.get, API_URL, params={'headword': query})
+    http_response = requests.get(API_URL, params={'headword': query})
 
     # Check if the response is OK
     if http_response.status_code != requests.codes.ok:
-        await bot.as_async.post_message(command.channel, "Problem fetching definition")
+        bot.post_message(command.channel, "Problem fetching definition")
         return
 
     json_data = json.loads(http_response.content)
@@ -33,4 +33,4 @@ async def define(command: Command):
         # This gets the first subsense if there are otherwise just uses senses.
         message = senses.get('subsenses', [senses])[0].get('definition', "Definition not available")
 
-    await bot.as_async.post_message(command.channel, f">>>{message}")
+    bot.post_message(command.channel, f">>>{message}")

--- a/uqcsbot/scripts/ecp.py
+++ b/uqcsbot/scripts/ecp.py
@@ -7,7 +7,7 @@ from uqcsbot.util.uq_course_util import (get_course_profile_url,
 
 @bot.on_command('ecp')
 @loading_status
-async def handle_ecp(command: Command):
+def handle_ecp(command: Command):
     '''
     `!ecp [COURSE CODE]` - Returns the link to the latest ECP for the given
     course code. If unspecified, will attempt to find the ECP for the channel

--- a/uqcsbot/scripts/events.py
+++ b/uqcsbot/scripts/events.py
@@ -95,7 +95,7 @@ class Event(object):
 
 
 @bot.on_command('events')
-async def handle_events(command: Command):
+def handle_events(command: Command):
     '''
     `!events [full|all|NUM EVENTS|<NUM WEEKS> weeks]` - Lists all the UQCS
     events that are scheduled to occur within the given filter. If unspecified,
@@ -103,10 +103,10 @@ async def handle_events(command: Command):
     '''
     event_filter = EventFilter.from_command(command)
     if not event_filter.is_valid:
-        await bot.as_async.post_message(command.channel, "Invalid events filter.")
+        bot.post_message(command.channel, "Invalid events filter.")
         return
 
-    http_response = await bot.run_async(requests.get, CALENDAR_URL)
+    http_response = requests.get(CALENDAR_URL)
     cal = Calendar.from_ical(http_response.content)
 
     current_time = datetime.now(tz=BRISBANE_TZ).astimezone(utc)
@@ -138,4 +138,4 @@ async def handle_events(command: Command):
     else:
         message = f"{event_filter.get_header()}\r\n" + '\r\n'.join(str(e) for e in events)
 
-    await bot.as_async.post_message(command.channel, message)
+    bot.post_message(command.channel, message)

--- a/uqcsbot/scripts/help.py
+++ b/uqcsbot/scripts/help.py
@@ -30,7 +30,7 @@ def get_helper_docs():
 
 @bot.on_command('help')
 @success_status
-async def handle_help(command: Command):
+def handle_help(command: Command):
     """
     `!help [COMMAND]` - Display the helper docstring for the given command. If
     unspecified, will return the helper docstrings for all commands.
@@ -44,6 +44,6 @@ async def handle_help(command: Command):
     if user_direct_channel is None:
         bot.logger.error(f'Could not find the calling user\'s channel: {command.user_id}')
     elif len(helper_docs) == 0:
-        await bot.as_async.post_message(user_direct_channel, f'Could not find any helper docstrings.')
+        bot.post_message(user_direct_channel, f'Could not find any helper docstrings.')
     else:
-        await bot.as_async.post_message(user_direct_channel, '>>>' + '\n'.join(helper_docs))
+        bot.post_message(user_direct_channel, '>>>' + '\n'.join(helper_docs))

--- a/uqcsbot/scripts/mock.py
+++ b/uqcsbot/scripts/mock.py
@@ -40,7 +40,7 @@ def mock_message(message: str):
     return ''.join(choice((c.upper, c.lower))() for c in message)
 
 @bot.on_command("mock")
-async def handle_mock(command: Command):
+def handle_mock(command: Command):
     '''
     `!mock [NUM POSTS]` - Mocks the message from the specified number of
     messages back. If no number is specified, mocks the most recent message.
@@ -58,4 +58,4 @@ async def handle_mock(command: Command):
             response = 'Something went wrong (likely insufficient conversation history).'
         else:
             response = mock_message(message_to_mock)
-    await bot.as_async.post_message(command.channel, response)
+    bot.post_message(command.channel, response)

--- a/uqcsbot/scripts/pastexams.py
+++ b/uqcsbot/scripts/pastexams.py
@@ -7,17 +7,17 @@ from uqcsbot.util.status_reacts import loading_status
 
 @bot.on_command('pastexams')
 @loading_status
-async def handle_pastexams(command: Command):
+def handle_pastexams(command: Command):
     '''
     `!pastexams [COURSE CODE]` - Retrieves past exams for a given course code.
     If unspecified, will attempt to find the ECP for the channel the command was
     called from.
     '''
     course_code = command.arg if command.has_arg() else command.channel.name
-    past_exams = await get_past_exams(course_code)
+    past_exams = get_past_exams(course_code)
 
     # We use attachments to improve the formatting
-    await bot.as_async.post_message(command.channel, "", attachments=[{'text': past_exams}])
+    bot.post_message(command.channel, "", attachments=[{'text': past_exams}])
 
 
 def get_exam_data(soup: BeautifulSoup) -> Iterable[Tuple[str, str]]:
@@ -51,7 +51,7 @@ async def get_past_exams(course_code: str) -> str:
     Gets the past exams for the course with the specified course code. Returns intuitive error messages if this fails.
     """
     url = 'https://www.library.uq.edu.au/exams/papers.php?'
-    http_response = await bot.run_async(requests.get, url, params={'stub': course_code})
+    http_response = requests.get(url, params={'stub': course_code})
 
     if http_response.status_code != requests.codes.ok:
         return "There was a problem getting a response"

--- a/uqcsbot/scripts/voteythumbs.py
+++ b/uqcsbot/scripts/voteythumbs.py
@@ -23,7 +23,7 @@ def strip(message: str, prefixes=VOTEYTHUMBS_STRIP_PREFIXES):
 
 
 @bot.on('message')
-async def voteythumbs(evt: dict):
+def voteythumbs(evt: dict):
     '''
     `!voteythumbs <TOPIC>` - Starts a :thumbsup: :thumbsdown: vote on the given
     topic. If unspecified, will not set a topic.
@@ -35,20 +35,20 @@ async def voteythumbs(evt: dict):
     if cmd is None:
         return
     if not cmd.has_arg() and "!voteythumbs" in evt["text"]:
-        await bot.as_async.post_message(cmd.channel, "Invalid voteythumbs command")
+        bot.post_message(cmd.channel, "Invalid voteythumbs command")
     if not cmd.has_arg():
         bot.logger.error("Invalid voteythumbs command")
         return
     cmd.arg = strip(cmd.arg)
 
-    result = await bot.as_async.post_message(cmd.channel, f"Starting vote: {cmd.arg}")
+    result = bot.post_message(cmd.channel, f"Starting vote: {cmd.arg}")
     add_reaction = partial(
-        bot.as_async.api.reactions.add,
+        bot.api.reactions.add,
         channel=cmd.channel.id,
         timestamp=result['ts'],
     )
     for emoji in ["thumbsup", "thumbsdown", "eyes"]:
-        res = await add_reaction(name=emoji)
+        res = add_reaction(name=emoji)
         if not res.get('ok'):
             bot.logger.error(f"Voteythumbs error adding \"{emoji}\": {res}")
             return

--- a/uqcsbot/scripts/wakie.py
+++ b/uqcsbot/scripts/wakie.py
@@ -3,7 +3,7 @@ from random import choice, sample
 from uqcsbot.util.status_reacts import LOADING_REACTS, HYPE_REACTS
 
 @bot.on_schedule('cron', hour=17, timezone='Australia/Brisbane')
-async def wakie():
+def wakie():
     '''
     'Wakes' up two UQCS members by pinging them on general and asking what
     they're working on.
@@ -13,7 +13,7 @@ async def wakie():
     channel = bot.channels.get("general")
     victims = sample(channel.members, 2)
     lines = [f'Hey <@{v}>! Tell us about something cool you are working on!' for v in victims]
-    wakie_message = await bot.as_async.post_message(channel, '\r\n'.join(lines))
-    await bot.as_async.api.reactions.add(name=choice(HYPE_REACTS + LOADING_REACTS),
+    wakie_message = bot.post_message(channel, '\r\n'.join(lines))
+    bot.api.reactions.add(name=choice(HYPE_REACTS + LOADING_REACTS),
                                          channel=channel.id,
                                          timestamp=wakie_message['ts'])

--- a/uqcsbot/scripts/welcome.py
+++ b/uqcsbot/scripts/welcome.py
@@ -2,7 +2,7 @@
 Welcomes new users to UQCS Slack and check for member milestones
 """
 from uqcsbot import bot
-import asyncio
+import time
 
 MEMBER_MILESTONE = 50  # Number of members between posting a celebration
 MESSAGE_PAUSE = 2.5   # Number of seconds between sending bot messages
@@ -18,7 +18,7 @@ WELCOME_MESSAGES = [    # Welcome messages sent to new members
 
 
 @bot.on("member_joined_channel")
-async def welcome(evt: dict):
+def welcome(evt: dict):
     """
     Welcomes new users to UQCS Slack and checks for member milestones
 
@@ -31,17 +31,17 @@ async def welcome(evt: dict):
     announcements = chan
     general = bot.channels.get("general")
 
-    user_info = await bot.as_async.api.users.info(user=evt.get("user"))
+    user_info = bot.api.users.info(user=evt.get("user"))
     display_name = user_info.get("user", {}).get("profile", {}).get("display_name")
 
     if display_name:
-        await bot.as_async.post_message(general, f"Welcome, {display_name}")
+        bot.post_message(general, f"Welcome, {display_name}")
 
     for message in WELCOME_MESSAGES:
-        await asyncio.sleep(MESSAGE_PAUSE)
-        await bot.as_async.post_message(evt.get("user"), message)
+        time.sleep(MESSAGE_PAUSE)
+        bot.post_message(evt.get("user"), message)
     if len(announcements.members) % MEMBER_MILESTONE == 0:
-        await bot.as_async.post_message(
+        bot.post_message(
             general,
             f":tada: {len(announcements.members)} members! :tada:"
         )

--- a/uqcsbot/scripts/wiki.py
+++ b/uqcsbot/scripts/wiki.py
@@ -4,30 +4,30 @@ import json
 
 
 @bot.on_command("wiki")
-async def handle_wiki(command: Command):
+def handle_wiki(command: Command):
     '''
     `!wiki <TOPIC>` - Returns a snippet of text from a relevent wikipedia entry.
     '''
     search_query = command.arg
     api_url = f"https://en.wikipedia.org/w/api.php?action=opensearch&format=json&limit=2"
 
-    http_response = await bot.run_async(requests.get, api_url, params={'search': search_query})
+    http_response = requests.get(api_url, params={'search': search_query})
     if http_response.status_code != requests.codes.ok:
-        await bot.as_async.post_message(command.channel, "Problem fetching data")
+        bot.post_message(command.channel, "Problem fetching data")
         return
 
     _, title_list, snippet_list, url_list = json.loads(http_response.content)
 
     # If the results are empty let them know. Any list being empty signifies this.
     if len(title_list) == 0:
-        await bot.as_async.post_message(command.channel, "No Results Found.")
+        bot.post_message(command.channel, "No Results Found.")
         return
 
     title, snippet, url = title_list[0], snippet_list[0], url_list[0]
 
     # Sometimes the first element is an empty string which is weird so we handle that rare case here
     if len(title) == 0 or len(snippet) == 0 or len(url) == 0:
-        await bot.as_async.post_message(command.channel, "Sorry, there was something funny about the result")
+        bot.post_message(command.channel, "Sorry, there was something funny about the result")
         return
 
     # Detect if there are multiple references to the query
@@ -38,4 +38,4 @@ async def handle_wiki(command: Command):
 
     # The first url and title matches the first snippet containing any content
     message = f'{title}: {snippet}\nLink: {url}'
-    await bot.as_async.post_message(command.channel, message)
+    bot.post_message(command.channel, message)


### PR DESCRIPTION
Swap all the core stuff for a single function `bot.get_event_loop()`, which allows you to use asyncio within the scope of a single command by getting an event loop.

All commands are run in threads using a `concurrent.futures.ThreadPoolExecutor`.

Coroutines as commands no longer works.

Fixes #282. Fixes #292.