### PR TITLE
Added exception handling for unparsable dates

### DIFF
--- a/uqcsbot/util/uq_course_util.py
+++ b/uqcsbot/util/uq_course_util.py
@@ -122,7 +122,12 @@ def is_assessment_after_cutoff(assessment, cutoff):
     '''
     Returns whether the assessment occurs after the given cutoff.
     '''
-    start_datetime, end_datetime = get_parsed_assessment_due_date(assessment)
+    try:
+        start_datetime, end_datetime = get_parsed_assessment_due_date(assessment)
+    except DateSyntaxException as e:
+        bot.logger.Error(e.message)
+        # If we can't parse a date, we're better off keeping it just in case.
+        return True
     return end_datetime >= cutoff if end_datetime else start_datetime >= cutoff
 
 def get_course_assessment(course_names, cutoff):

--- a/uqcsbot/util/uq_course_util.py
+++ b/uqcsbot/util/uq_course_util.py
@@ -127,6 +127,8 @@ def is_assessment_after_cutoff(assessment, cutoff):
     except DateSyntaxException as e:
         bot.logger.Error(e.message)
         # If we can't parse a date, we're better off keeping it just in case.
+        # TODO(mitch): Keep track of these instances to attempt to accurately
+        # parse them in future. Will require manual detection + parsing.
         return True
     return end_datetime >= cutoff if end_datetime else start_datetime >= cutoff
 


### PR DESCRIPTION
This PR makes it so that if we can't parse a due date, we assume that it has not passed yet and return it to the user. This is better than the alternative of just not showing it at all.

Ideally, we want to be able to parse all potential due dates. As such, I've added a TODO for this; but this PR fix should suffice for now.