### PR TITLE
Added auto reconnect and no team state flags

### DIFF
--- a/uqcsbot/base.py
+++ b/uqcsbot/base.py
@@ -213,7 +213,7 @@ class UQCSBot(object):
             # Initialise channels at start so we don't have to block
             self.channels._initialise()
 
-            if not self.client.rtm_connect():
+            if not self.client.rtm_connect(with_team_state=False, auto_reconnect=True):
                 raise OSError("Error connecting to RTM API")
             while True:
                 for message in self.client.rtm_read():


### PR DESCRIPTION
The slack client library we're using provides auto-reconnect logic for us that we weren't using. This PR adds that logic through setting the `auto_reconnect` flag and also sets the `with_team_state` flag to `False` for a lighter connection (which is recommended for larger teams such as ours)

See: https://slackapi.github.io/python-slackclient/real_time_messaging.html#rtm-start-vs-rtm-connect