### PR TITLE
!latex: Remove errors on message types without `text` attr

### DIFF
--- a/uqcsbot/scripts/latex.py
+++ b/uqcsbot/scripts/latex.py
@@ -33,7 +33,8 @@ def handle_latex_cmd(command: Command):
 
 @bot.on('message')
 def handle_latex_evt(evt):
-    if evt.get('subtype') == "bot_message":
+    if 'subtype' in evt:
+        # Only handle evt on raw messages from users
         return
     match = re.search(r"\$\$(.+)\$\$", evt['text'])
     if match is None:


### PR DESCRIPTION
This is a bit more general than the title implies, but it fixes the constant errors in logs whenever someone updates a message.