### PR TITLE
Fix for umart

### DIFF
--- a/test/test_umart.py
+++ b/test/test_umart.py
@@ -8,15 +8,15 @@ NO_QUERY_MESSAGE = "You can't look for nothing. `!umart <QUERY>`"
 NO_RESULTS_MESSAGE = "I can't find anything. Try `!umart <SOMETHING NOT AS SPECIFIC>`"
 ERROR_MESSAGE = "I tried to get the things but alas I could not. Error with HTTP Request."
 
-GOOD_MESSAGE = """```Name: <https://www.umart.com.au/umart1|Product1>
+GOOD_MESSAGE = """```Name: <https://www.umart.com.au/umart1/pro/Product1|Product1>
 Price: $1999.00
-Name: <https://www.umart.com.au/umart2|Product2>
+Name: <https://www.umart.com.au/umart1/pro/Product2|Product2>
 Price: $1099.00
-Name: <https://www.umart.com.au/umart3|Product3>
+Name: <https://www.umart.com.au/umart1/pro/Product3|Product3>
 Price: $1399.00
-Name: <https://www.umart.com.au/umart4|Product4>
+Name: <https://www.umart.com.au/umart1/pro/Product4|Product4>
 Price: $1269.00
-Name: <https://www.umart.com.au/umart5|Product5>
+Name: <https://www.umart.com.au/umart1/pro/Product5|Product5>
 Price: $1239.00
 ```"""
 

--- a/test/umart_products_list_search.html
+++ b/test/umart_products_list_search.html
@@ -4,7 +4,7 @@
                      <li style=" background:#D2EEFA">
 
               <dl style="padding-left: 5px;">
-               <dt style="width:262px"><a href="https://www.umart.com.au/umart1" class="proname">Product1</a></dt>
+               <dt style="width:262px"><a href="Product1" class="proname">Product1</a></dt>
                 <dd>  
                 </dd>
                 <dd>
@@ -21,7 +21,7 @@
         	            <li>
 
               <dl style="padding-left: 5px;">
-               <dt style="width:262px"><a href="https://www.umart.com.au/umart2" class="proname">Product2</a></dt>
+               <dt style="width:262px"><a href="Product2" class="proname">Product2</a></dt>
                 <dd>  
                 </dd>
                 <dd>
@@ -38,7 +38,7 @@
         	            <li style=" background:#D2EEFA">
 
               <dl style="padding-left: 5px;">
-               <dt style="width:262px"><a href="https://www.umart.com.au/umart3" class="proname">Product3</a></dt>
+               <dt style="width:262px"><a href="Product3" class="proname">Product3</a></dt>
                 <dd>  
                 </dd>
                 <dd>
@@ -55,7 +55,7 @@
         	            <li>
 
               <dl style="padding-left: 5px;">
-               <dt style="width:262px"><a href="https://www.umart.com.au/umart4" class="proname">Product4</a></dt>
+               <dt style="width:262px"><a href="Product4" class="proname">Product4</a></dt>
                 <dd>  
                 </dd>
                 <dd>
@@ -72,7 +72,7 @@
         	            <li style=" background:#D2EEFA">
 
               <dl style="padding-left: 5px;">
-               <dt style="width:262px"><a href="https://www.umart.com.au/umart5" class="proname">Product5</a></dt>
+               <dt style="width:262px"><a href="Product5" class="proname">Product5</a></dt>
                 <dd>  
                 </dd>
                 <dd>

--- a/uqcsbot/scripts/umart.py
+++ b/uqcsbot/scripts/umart.py
@@ -10,6 +10,7 @@ NO_RESULTS_MESSAGE = "I can't find anything. Try `!umart <SOMETHING NOT AS SPECI
 ERROR_MESSAGE = "I tried to get the things but alas I could not. Error with HTTP Request."
 
 UMART_SEARCH_URL = "https://www.umart.com.au/umart1/pro/products_list_searchnew_min.phtml"
+UMART_PRODUCT_URL = "https://www.umart.com.au/umart1/pro/"
 
 
 @bot.on_command("umart")
@@ -36,7 +37,7 @@ def handle_umart(command: Command):
         return
     message = "```"
     for result in search_results:
-        message += f"Name: <{result['link']}|{result['name']}>\n"
+        message += f"Name: <{UMART_PRODUCT_URL}{result['link']}|{result['name']}>\n"
         message += f"Price: {result['price']}\n"
     message += "```"
     bot.post_message(command.channel_id, message)


### PR DESCRIPTION
Turns out that when you download HTML it expands it to the full link and not just the identifier as seen when inspecting elements in the browser. For whatever reason, I didn't catch this and changed the formatting thinking I had borked it earlier. 

This PR fixes that mistake.