### PR TITLE
Remove bots from welcome count

### DIFF
--- a/uqcsbot/scripts/welcome.py
+++ b/uqcsbot/scripts/welcome.py
@@ -21,7 +21,7 @@ WELCOME_MESSAGES = [    # Welcome messages sent to new members
 @bot.on("member_joined_channel")
 def welcome(evt: dict):
     """
-    Welcomes new users to UQCS Slack and checks for member milestones
+    Welcomes new users to UQCS Slack and checks for member milestones.
 
     @no_help
     """
@@ -33,18 +33,21 @@ def welcome(evt: dict):
     general = bot.channels.get("general")
     user = bot.users.get(evt.get("user"))
 
-    if user and not user.is_bot:
-        bot.post_message(general, f"Welcome, <@{user.user_id}>!")
-        for message in WELCOME_MESSAGES:
-            time.sleep(MESSAGE_PAUSE)
-            bot.post_message(evt.get("user"), message)
-
     valid_users = len([
         member_id
         for member_id in announcements.members
         # getattr used so `None` members count as "deleted"
         if not getattr(bot.users.get(member_id), "deleted", True)
+        and not bot.users.get(member_id).is_bot
     ])
-    bot.logger.info(f"Currently at {valid_users} members")
+
+    # Alert general of a member milestone.
     if valid_users % MEMBER_MILESTONE == 0:
         bot.post_message(general, f":tada: {valid_users} members! :tada:")
+
+    # Send new user their welcome messages.
+    if user and not user.is_bot:
+        bot.post_message(general, f"Welcome, <@{user.user_id}>!")
+        for message in WELCOME_MESSAGES:
+            time.sleep(MESSAGE_PAUSE)
+            bot.post_message(evt.get("user"), message)

--- a/uqcsbot/scripts/welcome.py
+++ b/uqcsbot/scripts/welcome.py
@@ -33,7 +33,14 @@ def welcome(evt: dict):
     general = bot.channels.get("general")
     user = bot.users.get(evt.get("user"))
 
-    valid_users = len([
+    if user is None or user.is_bot:
+        return
+
+    # Welcome user in general.
+    bot.post_message(general, f"Welcome, <@{user.user_id}>!")
+
+    # Calculate number of members, ignoring deleted users and bots.
+    num_members = len([
         member_id
         for member_id in announcements.members
         # getattr used so `None` members count as "deleted"
@@ -41,13 +48,11 @@ def welcome(evt: dict):
         and not bot.users.get(member_id).is_bot
     ])
 
-    # Alert general of a member milestone.
-    if valid_users % MEMBER_MILESTONE == 0:
-        bot.post_message(general, f":tada: {valid_users} members! :tada:")
+    # Alert general of any member milestone.
+    if num_members % MEMBER_MILESTONE == 0:
+        bot.post_message(general, f":tada: {num_members} members! :tada:")
 
     # Send new user their welcome messages.
-    if user and not user.is_bot:
-        bot.post_message(general, f"Welcome, <@{user.user_id}>!")
-        for message in WELCOME_MESSAGES:
-            time.sleep(MESSAGE_PAUSE)
-            bot.post_message(evt.get("user"), message)
+    for message in WELCOME_MESSAGES:
+        time.sleep(MESSAGE_PAUSE)
+        bot.post_message(user.user_id, message)

--- a/uqcsbot/scripts/welcome.py
+++ b/uqcsbot/scripts/welcome.py
@@ -40,13 +40,12 @@ def welcome(evt: dict):
     bot.post_message(general, f"Welcome, <@{user.user_id}>!")
 
     # Calculate number of members, ignoring deleted users and bots.
-    num_members = len([
-        member_id
-        for member_id in announcements.members
-        # getattr used so `None` members count as "deleted"
-        if not getattr(bot.users.get(member_id), "deleted", True)
-        and not bot.users.get(member_id).is_bot
-    ])
+    num_members = 0
+    for member_id in announcements.members:
+        member = bot.users.get(member_id)
+        if member is None or member.deleted or member.is_bot:
+            continue
+        num_members += 1
 
     # Alert general of any member milestone.
     if num_members % MEMBER_MILESTONE == 0:


### PR DESCRIPTION
As per title. This move was made such that the member count accurately reflects the number provided by slack-- which seems to ignore bots.

I also moved the time consuming welcome messages to after the milestone calculation as there is a large gap between the "Welcome, {USER}!" and ":tada: XXXX members! :tada:" otherwise.