### PR TITLE
Patched member leaving channel bug

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -14,37 +14,40 @@ import uqcsbot as uqcsbot_module
 from uqcsbot.api import APIWrapper
 from uqcsbot.base import UQCSBot, Command
 
-# Arbitrary channel and user ids for use in testing
+# Convenient (but arbitrary) channels and users for use in testing
 TEST_CHANNEL_ID = "C1234567890"
 TEST_GROUP_ID = "G1234567890"
 TEST_DIRECT_ID = "D1234567890"
 TEST_USER_ID = "U1234567890"
 TEST_BOT_ID = "B1234567890"
+TEST_USERS = {
+    # Bot user
+    TEST_BOT_ID: {'id': TEST_BOT_ID, 'name': TEST_BOT_ID, 'deleted': False,
+                  'is_bot': True, 'profile': {'display_name': TEST_BOT_ID}},
+    # Regular user
+    TEST_USER_ID: {'id': TEST_USER_ID, 'name': TEST_USER_ID, 'deleted': False,
+                   'profile': {'display_name': TEST_USER_ID}}
+}
+TEST_CHANNELS = {
+    # Public channel
+    TEST_CHANNEL_ID: {'id': TEST_CHANNEL_ID, 'name': TEST_CHANNEL_ID,
+                      'is_public': True, 'members': [TEST_USER_ID]},
+    # Group channel
+    TEST_GROUP_ID: {'id': TEST_GROUP_ID, 'name': TEST_GROUP_ID, 'is_group': True,
+                    'is_private': True, 'members': [TEST_USER_ID]},
+    # Direct channel
+    TEST_DIRECT_ID: {'id': TEST_DIRECT_ID, 'name': TEST_DIRECT_ID, 'is_im': True,
+                     'is_private': True, 'is_user_deleted': False,
+                     'user': TEST_USER_ID}
+}
 
 
 class MockUQCSBot(UQCSBot):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.test_users = {
-            TEST_BOT_ID: {'id': TEST_BOT_ID, 'name': TEST_BOT_ID, 'deleted': False,
-                          'profile': {'display_name': TEST_BOT_ID}, 'is_bot': True},
-            TEST_USER_ID: {'id': TEST_USER_ID, 'name': TEST_USER_ID, 'deleted': False,
-                           'profile': {'display_name': TEST_USER_ID}}
-        }
         self.test_messages = defaultdict(list)
-        self.test_channels = {
-            # Public channel
-            TEST_CHANNEL_ID: {'id': TEST_CHANNEL_ID, 'name': TEST_CHANNEL_ID,
-                              'is_public': True, 'members': [TEST_USER_ID]},
-            # Group channel
-            TEST_GROUP_ID: {'id': TEST_GROUP_ID, 'name': TEST_GROUP_ID,
-                            'is_group': True, 'is_private': True,
-                            'members': [TEST_USER_ID]},
-            # Direct channel
-            TEST_DIRECT_ID: {'id': TEST_DIRECT_ID, 'name': TEST_DIRECT_ID,
-                             'is_im': True, 'is_private': True,
-                             'is_user_deleted': False, 'user': TEST_USER_ID}
-        }
+        self.test_users = TEST_USERS.copy()
+        self.test_channels = TEST_CHANNELS.copy()
 
         def mocked_api_call(method, **kwargs):
             '''
@@ -321,5 +324,7 @@ def uqcsbot(_uqcsbot: MockUQCSBot):
     _uqcsbot.users._initialise()
     yield _uqcsbot
     # Anything after yield will be run after test
-    # Clear channel messages
+    # Clear messages, users and channels
     _uqcsbot.test_messages.clear()
+    _uqcsbot.test_users = TEST_USERS.copy()
+    _uqcsbot.test_channels = TEST_CHANNELS.copy()

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -13,6 +13,7 @@ from slackclient import SlackClient
 import uqcsbot as uqcsbot_module
 from uqcsbot.api import APIWrapper
 from uqcsbot.base import UQCSBot, Command
+from copy import deepcopy
 
 # Convenient (but arbitrary) channels and users for use in testing
 TEST_CHANNEL_ID = "C1234567890"
@@ -46,8 +47,8 @@ class MockUQCSBot(UQCSBot):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.test_messages = defaultdict(list)
-        self.test_users = TEST_USERS.copy()
-        self.test_channels = TEST_CHANNELS.copy()
+        self.test_users = deepcopy(TEST_USERS)
+        self.test_channels = deepcopy(TEST_CHANNELS)
 
         def mocked_api_call(method, **kwargs):
             '''
@@ -326,5 +327,5 @@ def uqcsbot(_uqcsbot: MockUQCSBot):
     # Anything after yield will be run after test
     # Clear messages, users and channels
     _uqcsbot.test_messages.clear()
-    _uqcsbot.test_users = TEST_USERS.copy()
-    _uqcsbot.test_channels = TEST_CHANNELS.copy()
+    _uqcsbot.test_users = deepcopy(TEST_USERS)
+    _uqcsbot.test_channels = deepcopy(TEST_CHANNELS)

--- a/test/test_welcome.py
+++ b/test/test_welcome.py
@@ -1,6 +1,6 @@
 from test.conftest import MockUQCSBot, TEST_USER_ID, TEST_DIRECT_ID
 from test.helpers import (generate_event_object, MESSAGE_TYPE_CHANNEL_CREATED,
-                          MESSAGE_TYPE_MEMBER_JOINED_CHANNEL)
+                          MESSAGE_TYPE_MEMBER_JOINED_CHANNEL, MESSAGE_TYPE_TEAM_JOIN)
 from unittest.mock import patch
 
 # TODO(mitch): replace this with the milestone number once you've worked out how
@@ -47,11 +47,17 @@ def test_welcome_milestone(uqcsbot: MockUQCSBot):
                               channel={'id': 'announcements', 'name': 'announcements',
                                        'is_public': True}),
     ]
-    for _ in range(MEMBER_MILESTONE):
-        events.append(
+    for i in range(MEMBER_MILESTONE):
+        user_id = 'U' + str(i).rjust(10, '0')
+        uqcsbot.test_users[user_id] = {'id': user_id}
+        uqcsbot.test_channels[user_id] = {'id': user_id, 'name': user_id}
+        events.extend((
+            generate_event_object(MESSAGE_TYPE_CHANNEL_CREATED,
+                                  channel={'id': user_id, 'name': user_id}),
+            generate_event_object(MESSAGE_TYPE_TEAM_JOIN, user={'id': user_id}),
             generate_event_object(MESSAGE_TYPE_MEMBER_JOINED_CHANNEL,
-                                  channel='announcements', user=TEST_USER_ID)
-        )
+                                  channel='announcements', user=user_id)
+        ))
     with patch('time.sleep') as mock_sleep:
         mock_sleep.return_value = None
         for event in events:

--- a/uqcsbot/api.py
+++ b/uqcsbot/api.py
@@ -290,15 +290,15 @@ class ChannelWrapper(object):
 
     def _on_member_joined_channel(self, evt):
         chan = self.get(evt['channel'])
-        members = chan.members
         with chan._lock:
-            members.append(evt['user'])
+            chan.members.append(evt['user'])
 
     def _on_member_left_channel(self, evt):
         chan = self.get(evt['channel'])
-        members = chan.members
         with chan._lock:
-            members.remove(evt['user'])
+            user = evt['user']
+            if user in chan.members:
+                chan.members.remove(user)
 
     def _on_channel_rename(self, evt):
         with self._lock:

--- a/uqcsbot/scripts/welcome.py
+++ b/uqcsbot/scripts/welcome.py
@@ -46,5 +46,5 @@ def welcome(evt: dict):
         if not getattr(bot.users.get(member_id), "deleted", True)
     ])
     bot.logger.info(f"Currently at {valid_users} members")
-    if valid_users % MEMBER_MILESTONE == 0:
+    if valid_users > 0 and valid_users % MEMBER_MILESTONE == 0:
         bot.post_message(general, f":tada: {valid_users} members! :tada:")


### PR DESCRIPTION
we were getting `ValueError: list.remove(x): x not in list` errors upon members leaving channels, so I added a check before adding/removing a member. This required updating the test suite, which previously was only adding one member type 50 times. I added the ability to properly add test users and channels while fixing those tests.