### PR TITLE
Patched !yt

### DIFF
--- a/uqcsbot/scripts/yt.py
+++ b/uqcsbot/scripts/yt.py
@@ -54,7 +54,7 @@ def execute_search(search_query: str, search_part: str, search_type: str, max_re
     Executes the search via the google api client based on the parameters given.
     '''
     youtube = build(YOUTUBE_API_SERVICE_NAME, YOUTUBE_API_VERSION,
-                    developerKey=YOUTUBE_API_KEY)
+                    developerKey=YOUTUBE_API_KEY, cache_discovery=False)
 
     search_response = youtube.search().list(
         q=search_query,


### PR DESCRIPTION
We were getting these errors whenever !yt was used:

```
WARNING:googleapiclient.discovery_cache:file_cache is unavailable when using oauth2client >= 4.0.0 or google-auth
Traceback (most recent call last):
  File "/srv/uqcsbot/lib/python3.6/site-packages/googleapiclient/discovery_cache/__init__.py", line 36, in autodetect
    from google.appengine.api import memcache
ModuleNotFoundError: No module named 'google.appengine'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/srv/uqcsbot/lib/python3.6/site-packages/googleapiclient/discovery_cache/file_cache.py", line 33, in <module>
    from oauth2client.contrib.locked_file import LockedFile
ModuleNotFoundError: No module named 'oauth2client'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/srv/uqcsbot/lib/python3.6/site-packages/googleapiclient/discovery_cache/file_cache.py", line 37, in <module>
    from oauth2client.locked_file import LockedFile
ModuleNotFoundError: No module named 'oauth2client'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/srv/uqcsbot/lib/python3.6/site-packages/googleapiclient/discovery_cache/__init__.py", line 41, in autodetect
    from . import file_cache
  File "/srv/uqcsbot/lib/python3.6/site-packages/googleapiclient/discovery_cache/file_cache.py", line 41, in <module>
    'file_cache is unavailable when using oauth2client >= 4.0.0 or google-auth')
ImportError: file_cache is unavailable when using oauth2client >= 4.0.0 or google-auth
```

Disabling file cache fixes this.