### PR TITLE
Fixed !whatsdue for semester 2 (fixes #369)

### DIFF
--- a/uqcsbot/utils/uq_course_utils.py
+++ b/uqcsbot/utils/uq_course_utils.py
@@ -9,7 +9,7 @@ from binascii import hexlify
 BASE_COURSE_URL = 'https://my.uq.edu.au/programs-courses/course.html?course_code='
 BASE_ASSESSMENT_URL = 'https://www.courses.uq.edu.au/student_section_report.php?report=assessment&profileIds=' # noqa
 BASE_CALENDAR_URL = 'http://www.uq.edu.au/events/calendar_view.php?category_id=16&year='
-OFFERING_QUERY = '&offer='
+OFFERING_PARAMETER = 'offer'
 
 
 class DateSyntaxException(Exception):
@@ -74,8 +74,10 @@ def get_course_profile_url(course_name):
     '''
     Returns the URL to the latest course profile for the given course.
     '''
-    course_url = BASE_COURSE_URL + course_name + OFFERING_QUERY + get_offering_code()
-    http_response = requests.get(course_url)
+    course_url = BASE_COURSE_URL + course_name
+    http_response = requests.get(
+        course_url, params={OFFERING_PARAMETER: get_offering_code()}
+    )
     if http_response.status_code != requests.codes.ok:
         raise HttpException(course_url, http_response.status_code)
     html = BeautifulSoup(http_response.content, 'html.parser')

--- a/uqcsbot/utils/uq_course_utils.py
+++ b/uqcsbot/utils/uq_course_utils.py
@@ -176,7 +176,7 @@ def get_course_assessment(course_names, cutoff=None):
     assessment = assessment_table.findAll('tr')[1:]
     parsed_assessment = map(get_parsed_assessment_item, assessment)
     # If no cutoff is specified, set cutoff to UNIX epoch (i.e. filter nothing).
-    cutoff = cutoff or datetime.fromtimestamp(0)
+    cutoff = cutoff or datetime.min
     assessment_filter = partial(is_assessment_after_cutoff, cutoff=cutoff)
     filtered_assessment = filter(assessment_filter, parsed_assessment)
     return list(filtered_assessment)

--- a/uqcsbot/utils/uq_course_utils.py
+++ b/uqcsbot/utils/uq_course_utils.py
@@ -67,7 +67,7 @@ def get_offering_code(semester=None, campus='STLUC', is_internal=True):
     if semester is None:
         semester = 1 if datetime.today().month <= 6 else 2
     location = 'IN' if is_internal else 'EX'
-    return hexlify(b'{campus}{semester}{location}').decode('utf-8')
+    return hexlify(f'{campus}{semester}{location}'.encode('utf-8')).decode('utf-8')
 
 
 def get_course_profile_url(course_name):


### PR DESCRIPTION
Computes the hex offering string to use in get_course_profile_url so the current semester is highlighted and parsed.

In June and earlier, gets semester 1, otherwise gets semester 2. This is the same as get_current_exam_period so it should be fine..? I couldn't really test this because #369 only occurred when both semesters 1 and 2 were listed under "Current course offerings" during the first couple weeks of sem 2.

Also, it would be nice to have an argument in !whatsdue for which semester and campus to query.