### PR TITLE
Update !radar with new caching

### DIFF
--- a/uqcsbot/scripts/radar.py
+++ b/uqcsbot/scripts/radar.py
@@ -7,6 +7,6 @@ def handle_radar(command: Command):
     '''
     `!radar` - Returns the latest BOM radar image for Brisbane.
     '''
-    time_in_ms = int(round(time() * 1000))
-    radar_url = f'https://bom.lambda.tools/?location=brisbane&_cache={time_in_ms}'
+    time_in_s = int(time())
+    radar_url = f'https://bom.lambda.tools/?location=brisbane&timestamp={time_in_s}'
     bot.post_message(command.channel_id, radar_url)


### PR DESCRIPTION
A problem with the radar command is that it is fetched for each request, so it shows the radar at the time when it was loaded by the user, not when it was posted to slack. I've updated the service to take a timestamp and it'll use a cached image from that timestamp if available.