### PR TITLE
Post new xkcd comics on release

### DIFF
--- a/uqcsbot/scripts/xkcd.py
+++ b/uqcsbot/scripts/xkcd.py
@@ -85,7 +85,24 @@ def handle_xkcd(command: Command) -> None:
             response = get_by_search_phrase(command.arg)
     else:
         response = get_latest()
+
     bot.post_message(command.channel_id,
                      response,
+                     unfurl_links=True,
+                     unfurl_media=True)
+
+
+@bot.on_schedule('cron', hour=14, minute=1, day_of_week='mon,wed,fri', timezone='Australia/Brisbane')
+def new_xkcd():
+    """
+    Posts new xkcd comic when they are released every Monday, Wednesday
+    & Friday at 4AM UTC or 2PM Brisbane time.
+
+    @no_help
+    """
+    link = get_latest()
+    general = bot.channels.get("general")
+    bot.post_message(general.id,
+                     link,
                      unfurl_links=True,
                      unfurl_media=True)

--- a/uqcsbot/scripts/xkcd.py
+++ b/uqcsbot/scripts/xkcd.py
@@ -93,7 +93,7 @@ def handle_xkcd(command: Command) -> None:
 
 
 @bot.on_schedule('cron', hour=14, minute=1, day_of_week='mon,wed,fri', timezone='Australia/Brisbane')
-def new_xkcd():
+def new_xkcd() -> None:
     """
     Posts new xkcd comic when they are released every Monday, Wednesday
     & Friday at 4AM UTC or 2PM Brisbane time.


### PR DESCRIPTION
This is based on the current release timetable of 4AM UTC, Mon, Wed, Fri, but when we give the bot back its brain we can move this to checking the RSS feed to more safely avoid duplicates.