### PR TITLE
Add an -n to trivia and a daily trivia in #trivia

### DIFF
--- a/uqcsbot/scripts/trivia.py
+++ b/uqcsbot/scripts/trivia.py
@@ -28,7 +28,7 @@ MIN_SECONDS = 5
 MAX_SECONDS = 300
 
 # The channels where multiple trivia questions can be asked (prevent spam)
-# TODO: Let me know if you want this restriction or not
+
 VALID_SEQUETIAL_CHANNELS = ['trivia', 'bot-testing']
 MAX_SEQUENTIAL_QUESTIONS = 30
 

--- a/uqcsbot/scripts/trivia.py
+++ b/uqcsbot/scripts/trivia.py
@@ -2,9 +2,11 @@ import argparse
 import base64
 import json
 import random
-import requests
 from datetime import datetime, timezone, timedelta
-from typing import List, Dict, Union, NamedTuple
+from functools import partial
+from typing import List, Dict, Union, NamedTuple, Optional, Callable, Set
+
+import requests
 
 from uqcsbot import bot, Command
 from uqcsbot.api import Channel
@@ -15,7 +17,11 @@ CATEGORIES_URL = "https://opentdb.com/api_category.php"
 
 # NamedTuple for use with the data returned from the api
 QuestionData = NamedTuple('QuestionData',
-                          [('type', str), ('question', str), ('correct_answer', str), ('incorrect_answers', List[str])])
+                          [('type', str), ('question', str), ('correct_answer', str), ('answers', List[str]),
+                           ('is_boolean', bool)])
+
+# Contains information about a reaction and the list of users who used said reaction
+ReactionUsers = NamedTuple('ReactionUsers', [('name', str), ('users', Set[str])])
 
 # Customisation options
 MIN_SECONDS = 5
@@ -23,22 +29,27 @@ MAX_SECONDS = 300
 
 # The channels where multiple trivia questions can be asked (prevent spam)
 # TODO: Let me know if you want this restriction or not
-VALID_SEQUETIAL_CHANNELS = ['trivia', 'bot-testing', 'timtams']
+VALID_SEQUETIAL_CHANNELS = ['trivia', 'bot-testing']
 MAX_SEQUENTIAL_QUESTIONS = 30
 
 BOOLEAN_REACTS = ['this', 'not-this']  # Format of [ <True>, <False> ]
-MULTIPLE_CHOICE_REACTS = ['green_heart', 'yellow_heart', 'heart', 'blue_heart']
+MULTIPLE_CHOICE_REACTS = ['green_heart', 'yellow_heart', 'heart', 'blue_heart']  # Colours should match CHOICE_COLORS
 CHOICE_COLORS = ['#6C9935', '#F3C200', '#B6281E', '#3176EF']
+
+# What arguments to use for the cron job version
+CRON_CHANNEL = 'trivia'
+CRON_SECONDS = 86385  # (One day - 15 seconds) Overrides any -s argument below and ignores MAX_SECONDS rule
+CRON_ARGUMENTS = ''
 
 
 @bot.on_command('trivia')
 @loading_status
 def handle_trivia(command: Command):
     """
-        `!trivia [-d <easy|medium|hard>] [-c <CATEGORY>] [-t <multiple|tf>] [-s <N>] [--cats]`
+        `!trivia [-d <easy|medium|hard>] [-c <CATEGORY>] [-t <multiple|tf>] [-s <N>] [-n <N>] [--cats]`
             - Asks a new trivia question
     """
-    args = parse_arguments(command)
+    args = parse_arguments(command.channel_id, command.arg if command.has_arg() else '')
 
     # End early if the help option was used
     if args.help:
@@ -50,22 +61,28 @@ def handle_trivia(command: Command):
         return
 
     # Check if the channel is valid for sequential questions
-    if args.count > 1 and bot.channels.get(command.channel_id).name not in VALID_SEQUETIAL_CHANNELS:
+    current_channel = bot.channels.get(command.channel_id)
+    if args.count > 1 and not current_channel.is_im and current_channel.name not in VALID_SEQUETIAL_CHANNELS:
+        # If no valid channels are specified
+        if len(VALID_SEQUETIAL_CHANNELS) == 0:
+            bot.post_message(command.channel_id, 'This command can only be used in private messages with the bot')
+            return
+
+        first_valid = bot.channels.get(VALID_SEQUETIAL_CHANNELS[0])
+        channel_message = f'Try <#{first_valid.id}|{VALID_SEQUETIAL_CHANNELS[0]}>.' if first_valid else ''
         bot.post_message(command.channel_id,
-                         'You cannot use the sequential questions feature in this channel try #trivia')
+                         f'You cannot use the sequential questions feature in this channel. {channel_message}')
         return
 
-    handle_question(command, args)
+    handle_question(command.channel_id, args)
 
 
-def parse_arguments(command: Command) -> argparse.Namespace:
+def parse_arguments(channel: Channel, arg_string: str) -> argparse.Namespace:
     """
     Parses the arguments for the command
     :param command: The command which the handle_trivia function receives
     :return: An argpase Namespace object with the parsed arguments
     """
-    command_args = command.arg.split() if command.has_arg() else []
-
     parser = argparse.ArgumentParser(prog='!trivia', add_help=False)
 
     def usage_error(*args, **kwargs):
@@ -79,23 +96,27 @@ def parse_arguments(command: Command) -> argparse.Namespace:
                         help='The type of question. (default: %(default)s)')
     parser.add_argument('-s', '--seconds', default=30, type=int,
                         help='Number of seconds before posting answer (default: %(default)s)')
-    parser.add_argument('-n', '--count', default=1, type=int, help="Do 'n' trivia questions in quick succession")
+    parser.add_argument('-n', '--count', default=1, type=int,
+                        help=f"Do 'n' trivia questions in quick succession (max : {MAX_SEQUENTIAL_QUESTIONS})")
     parser.add_argument('--cats', action='store_true', help='Sends a list of valid categories to the user')
-    parser.add_argument('-h', '--help', action='store_true')
+    parser.add_argument('-h', '--help', action='store_true', help='Prints this help message')
 
-    args = parser.parse_args(command_args)
+    args = parser.parse_args(arg_string.split())
 
     # If the help option was used print the help message to the channel (needs access to the parser to do this)
     if args.help:
-        bot.post_message(command.channel_id, parser.format_help())
+        bot.post_message(channel, parser.format_help())
 
     # Constrain the number of seconds to a reasonable frame
-    args.seconds = max(args.seconds, MIN_SECONDS)
+    args.seconds = max(MIN_SECONDS, args.seconds)
     args.seconds = min(args.seconds, MAX_SECONDS)
 
     # Constrain the number of sequential questions
-    args.count = max(args.number, 1)
-    args.count = min(args.number, MAX_SEQUENTIAL_QUESTIONS)
+    args.count = max(args.count, 1)
+    args.count = min(args.count, MAX_SEQUENTIAL_QUESTIONS)
+
+    # Add an original count to keep track
+    args.original_count = args.count
 
     return args
 
@@ -119,46 +140,41 @@ def get_categories() -> str:
     return pretty_results
 
 
-def handle_question(command: Command, args: argparse.Namespace):
-    """Handles getting a question and posting it to the channel as well as scheduling the answer"""
-    question_data = get_question_data(command.channel_id, args)
+def handle_question(channel: Channel, args: argparse.Namespace):
+    """
+    Handles getting a question and posting it to the channel as well as scheduling the answer.
+    Returns the reaction string for the correct answer.
+    """
+    question_data = get_question_data(channel, args)
 
     if question_data is None:
         return
 
-    # The base 64 decoding ensures that the formatting works properly with slack
-    question = decode_b64(question_data.question)
-    correct_answer = decode_b64(question_data.correct_answer)
-    answers = [decode_b64(ans) for ans in question_data.incorrect_answers]
+    question_number = args.original_count - args.count + 1
+    prefix = f'Q{question_number}:' if args.original_count > 1 else ''
+    post_question(channel, question_data, prefix)
 
-    # Whether or not the question was a true/false question
-    is_boolean = len(answers) == 1
-
-    # Post the question and get the timestamp for the reactions (asterisks bold it)
-    message_ts = bot.post_message(command.channel_id, f'*{question}*')['ts']
-
-    # Print the questions (if multiple choice) and add the answer reactions
-    if is_boolean:
-        reactions = BOOLEAN_REACTS
-        answer_text = f':{BOOLEAN_REACTS[0]}:' if correct_answer == 'True' else f':{BOOLEAN_REACTS[1]}:'
+    # Get the answer message
+    if question_data.is_boolean:
+        answer_text = f':{BOOLEAN_REACTS[0]}:' if question_data.correct_answer == 'True' else f':{BOOLEAN_REACTS[1]}:'
     else:
-        reactions = MULTIPLE_CHOICE_REACTS
-        answer_text = correct_answer
+        answer_text = question_data.correct_answer
 
-        answers.append(correct_answer)
-        message_ts = post_possible_answers(command.channel_id, answers)
-
-    for reaction in reactions:
-        bot.api.reactions.add(name=reaction, channel=command.channel_id, timestamp=message_ts)
+    answer_message = f'The answer to the question *{question_data.question}* is: *{answer_text}*'
 
     # Schedule the answer to be posted after the specified number of seconds has passed
-    answer_message = f'*The answer is: {answer_text}*'
-    schedule_answer(command, answer_message, args.seconds)
+    post_answer = partial(bot.post_message, channel, answer_message)
+    schedule_action(post_answer, args.seconds)
+
+    # If more questions are to be asked schedule the question for 5 seconds after the current answer
+    if args.count > 1:
+        args.count -= 1
+        schedule_action(partial(handle_question, channel, args), args.seconds + 5)
 
 
-def get_question_data(channel: Channel, args: argparse.Namespace) -> QuestionData:
+def get_question_data(channel: Channel, args: argparse.Namespace) -> Optional[QuestionData]:
     """
-    Attempts to get a question from teh api using the specified arguments.
+    Attempts to get a question from the api using the specified arguments.
     Returns the dictionary object for the question on success and None on failure (after posting an error message).
     """
     # Base64 to help with encoding the message for slack
@@ -191,11 +207,47 @@ def get_question_data(channel: Channel, args: argparse.Namespace) -> QuestionDat
 
     question_data = response_content['results'][0]
 
+    # Get the type of question and make the NamedTuple container for the data
+    is_boolean = len(question_data['incorrect_answers']) == 1
+    answers = [question_data['correct_answer']] + question_data['incorrect_answers']
+
     # Delete the ones we don't need
     del question_data['category']
     del question_data['difficulty']
+    del question_data['incorrect_answers']
 
-    return QuestionData(**question_data)
+    # Decode the ones we want. The base 64 decoding ensures that the formatting works properly with slack.
+    question_data['question'] = decode_b64(question_data['question'])
+    question_data['correct_answer'] = decode_b64(question_data['correct_answer'])
+    answers = [decode_b64(ans) for ans in answers]
+
+    question_data = QuestionData(**question_data, is_boolean=is_boolean, answers=answers)
+
+    # Shuffle the answers
+    random.shuffle(question_data.answers)
+
+    return question_data
+
+
+def post_question(channel: Channel, question_data: QuestionData, prefix: str = '') -> float:
+    """
+    Posts the question from the given QuestionData along with the possible answers list if applicable.
+    Also creates the answer reacts.
+    Returns the timestamp of the posted message.
+    """
+    # Post the question and get the timestamp for the reactions (asterisks bold it)
+    message_ts = bot.post_message(channel, f'*{prefix} {question_data.question}*')['ts']
+
+    # Print the questions (if multiple choice) and add the answer reactions
+    reactions = BOOLEAN_REACTS if question_data.is_boolean else MULTIPLE_CHOICE_REACTS
+
+    if not question_data.is_boolean:
+        message_ts = post_possible_answers(channel, question_data.answers)
+
+    for reaction in reactions:
+        bot.api.reactions.add(name=reaction, channel=channel, timestamp=message_ts)
+
+    return message_ts
 
 
 def decode_b64(encoded: str) -> str:
@@ -203,13 +255,21 @@ def decode_b64(encoded: str) -> str:
     return base64.b64decode(encoded).decode('utf-8')
 
 
+def get_correct_reaction(question_data: QuestionData):
+    """Returns the reaction that matches with the correct answer"""
+    if question_data.is_boolean:
+        correct_reaction = BOOLEAN_REACTS[0] if question_data.correct_answer == 'True' else BOOLEAN_REACTS[1]
+    else:
+        correct_reaction = MULTIPLE_CHOICE_REACTS[question_data.answers.index(question_data.correct_answer)]
+
+    return correct_reaction
+
+
 def post_possible_answers(channel: Channel, answers: List[str]) -> float:
     """
     Posts the possible answers for a multiple choice question in a nice way.
     Returns the timestamp of the message to allow reacting to it.
     """
-    random.shuffle(answers)
-
     attachments = []
     for col, answer in zip(CHOICE_COLORS, answers):
         ans_att = {'text': answer, 'color': col}
@@ -218,9 +278,35 @@ def post_possible_answers(channel: Channel, answers: List[str]) -> float:
     return bot.post_message(channel, '', attachments=attachments)['ts']
 
 
-def schedule_answer(command: Command, answer: str, secs: int):
-    """Schedules the given answer to be posted to the channel after the given number of seconds"""
-    post_answer = lambda: bot.post_message(command.channel_id, answer)
-    end_date = datetime.now(timezone(timedelta(hours=10))) + timedelta(seconds=secs + 1)
+def schedule_action(action: Callable, secs: int):
+    """Schedules the supplied action to be called once in the given number of seconds."""
+    run_date = datetime.now(timezone(timedelta(hours=10))) + timedelta(seconds=secs)
+    bot._scheduler.add_job(action, 'date', run_date=run_date)
 
-    bot._scheduler.add_job(post_answer, 'interval', seconds=secs, end_date=end_date)
+
+@bot.on_schedule('cron', hour=12, timezone='Australia/Brisbane')
+def daily_trivia():
+    """Adds a job that displays a random question to the specified channel at lunch time"""
+    channel = bot.channels.get(CRON_CHANNEL).id
+
+    # Get arguments and update the seconds
+    args = parse_arguments(channel, CRON_ARGUMENTS)
+    args.seconds = CRON_SECONDS
+
+    # Get and post the actual question
+    handle_question(channel, args)
+
+    # Format a nice message to tell when the answer will be
+    hours = CRON_SECONDS//3600
+    minutes = (CRON_SECONDS - (hours * 3600))//60
+    if minutes > 55:
+        hours += 1
+        minutes = 0
+
+    time_until_answer = 'Answer in '
+    if hours > 0:
+        time_until_answer += f'{hours} hours'
+    if minutes > 0:
+        time_until_answer += f' and {minutes} minutes' if hours > 0 else f'{minutes} minutes'
+
+    bot.post_message(channel, time_until_answer)

--- a/uqcsbot/scripts/trivia.py
+++ b/uqcsbot/scripts/trivia.py
@@ -28,7 +28,6 @@ MIN_SECONDS = 5
 MAX_SECONDS = 300
 
 # The channels where multiple trivia questions can be asked (prevent spam)
-
 VALID_SEQUETIAL_CHANNELS = ['trivia', 'bot-testing']
 MAX_SEQUENTIAL_QUESTIONS = 30
 
@@ -221,7 +220,7 @@ def get_question_data(channel: Channel, args: argparse.Namespace) -> Optional[Qu
     question_data['correct_answer'] = decode_b64(question_data['correct_answer'])
     answers = [decode_b64(ans) for ans in answers]
 
-    question_data = QuestionData(**question_data, is_boolean=is_boolean, answers=answers)
+    question_data = QuestionData(is_boolean=is_boolean, answers=answers, **question_data)
 
     # Shuffle the answers
     random.shuffle(question_data.answers)


### PR DESCRIPTION
This adds an -n flag to the command which asks n questions in succession.

There is currently a question cap of 30 and the command is limited to the trivia and bot-testing channels to avoid spam. Let me know if you want this changed etc. 

There is no way to stop the sequence once it starts as that would require storing the job as far as I know? Can add this later along with the leaderboard (see below).

![sequential](https://user-images.githubusercontent.com/24851062/50685953-15819300-1067-11e9-84f2-371c986389b4.PNG)

This also adds a daily job to the trivia channel which asks a new question at 12. I also have a branch that contains the code for a persistent leaderboard that tracks everyone's scores on the daily trivia. 

I have not included it here while I wait for a proper interface on the bot for using the database and not a hacky solution. This is why there may be some extra code in there that isn't required right now. I hopefully removed most of it though.

![schedule](https://user-images.githubusercontent.com/24851062/50685895-e2d79a80-1066-11e9-8745-b6ca51b2e6a1.PNG)
