### PR TITLE
Add a constraint on `websocket-client`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,9 @@ with open(path.join(here, 'README.md'), encoding='utf-8') as f:
 
 install_requires = [
     'slackclient',
+    # slackclient doesn't constrain websocket and 0.55.0 is hella broken
+    # TODO: delete this
+    'websocket-client==0.54.0',
     'requests',
     'BeautifulSoup4',
     'apscheduler',


### PR DESCRIPTION
Fixes the recent outage issue - a single read wasn't happening instantly so it was just reacting as if the socket was closed.