### PR TITLE
Expand radar image again to fix #387

### DIFF
--- a/uqcsbot/scripts/radar.py
+++ b/uqcsbot/scripts/radar.py
@@ -9,4 +9,8 @@ def handle_radar(command: Command):
     '''
     time_in_s = int(time())
     radar_url = f'https://bom.lambda.tools/?location=brisbane&timestamp={time_in_s}'
-    bot.post_message(command.channel_id, radar_url)
+    attachment = {"image_url": radar_url, "text": None,
+                  "fallback": "Screenshot from the Bureau of Meterology's"
+                  " Brisbane radar."}
+    bot.post_message(command.channel_id, radar_url,
+            attachments=[attachment])


### PR DESCRIPTION
Tested with a bot in uqcstesting. With this patch, we have pretty previews again.

I tried using the new [blocks API](https://api.slack.com/reference/messaging/blocks#image) instead of the old [attachments API](https://api.slack.com/docs/outmoded-messaging) but it seems to have a special grudge against bom.lambda.tools - worked fine with a similar URL from my ngrok.