### PR TITLE
Adds a !crates command

### DIFF
--- a/test/test_crates.py
+++ b/test/test_crates.py
@@ -1,0 +1,33 @@
+from test.conftest import MockUQCSBot, TEST_CHANNEL_ID
+
+
+def test_crates_exact(uqcsbot: MockUQCSBot):
+    """
+    Tests !crates with an exact crate search
+    """
+    uqcsbot.post_message(TEST_CHANNEL_ID, '!crates regex')
+    messages = uqcsbot.test_messages.get(TEST_CHANNEL_ID, [])
+
+    assert len(messages) == 2
+
+
+def test_crates_search(uqcsbot: MockUQCSBot):
+    """
+    Tests !crates search by searching for a specific thing
+    """
+    uqcsbot.post_message(TEST_CHANNEL_ID, '!crates search rand -l 2 --sort downloads -c algorithms')
+    messages = uqcsbot.test_messages.get(TEST_CHANNEL_ID, [])
+
+    assert len(messages) == 2
+
+
+def test_categories(uqcsbot: MockUQCSBot):
+    """
+    Tests the !trivia categories sub command
+    """
+    uqcsbot.post_message(TEST_CHANNEL_ID, "!crates categories")
+    uqcsbot.post_message(TEST_CHANNEL_ID, "!crates categories algorithms")
+
+    messages = uqcsbot.test_messages.get(TEST_CHANNEL_ID, [])
+
+    assert len(messages) == 4

--- a/uqcsbot/scripts/crates.py
+++ b/uqcsbot/scripts/crates.py
@@ -549,7 +549,10 @@ def handle_categories_route(channel: Channel, args: CategorySearch):
 
 
 def get_user(channel: Channel, username: str) -> Optional[UserResult]:
-    """Gets a UserResult by querying the api for the given username. None on error."""
+    """
+    Gets a UserResult by querying the crates.io api for the given username.
+    None on error.
+    """
     url = f'{BASE_URL}/users/{username}'
     response = requests.get(url)
 

--- a/uqcsbot/scripts/crates.py
+++ b/uqcsbot/scripts/crates.py
@@ -1,5 +1,6 @@
 import argparse
 import json
+from enum import Enum
 from typing import NamedTuple, Union, Optional, List, Dict, Tuple
 
 import requests
@@ -14,7 +15,10 @@ MAX_LIMIT = 15  # The maximum number of search results from one call to the comm
 # NamedTuple for the case that the argparse finds a -h flag
 HelpCommand = NamedTuple('HelpCommand', [('help_string', str)])
 
-# NamedTuple for the default command that deals with searching for specific crates
+# NamedTuple for the default command that finds a crate by exact name match
+ExactCrate = NamedTuple('ExactCrate', [('name', str)])
+
+# NamedTuple for the search sub-command that deals with searching for specific crates
 CrateSearch = NamedTuple('CrateSearch',
                          [('name', str), ('limit', int), ('category', str), ('user', str), ('sort', str),
                           ('search', str)])
@@ -22,8 +26,19 @@ CrateSearch = NamedTuple('CrateSearch',
 # NamedTuple for the default categories sub-command that deals with searching for categories
 CategorySearch = NamedTuple('CategorySearch', [('name', str), ('limit', int), ('sort', str)])
 
+# NamedTuple for the user sub-command that deals with searching for specific users
+UserSearch = NamedTuple('UserSearch', [('username', str)])
+
 # Named tuple for a crate that was found in a search
 CrateResult = NamedTuple('CrateResult', [('name', str), ('downloads', int), ('homepage', str), ('description', str)])
+
+
+class SubCommand(Enum):
+    """Distinguishes the type of sub command that was invoked"""
+    EXACT = 1,
+    SEARCH = 2,
+    CATEGORIES = 3
+
 
 @bot.on_command('crates')
 @loading_status
@@ -32,15 +47,14 @@ def handle_crates(command: Command):
     `!crates `
             - Get information about crates from crates.io
     """
-    args = parse_arguments(command.channel_id, command.arg if command.has_arg() else '')
+    args = parse_arguments(command.arg if command.has_arg() else '')
 
     args.execute_action(command.channel_id, args)  # type: ignore
 
 
-def parse_arguments(channel: Channel, arg_str: str) -> Union[HelpCommand, CrateSearch, CategorySearch]:
+def parse_arguments(arg_str: str) -> Union[HelpCommand, CrateSearch, CategorySearch]:
     """
     Parses the arguments passed to the command
-    :param channel: The channel to post help to (help message needs access to parser)
     :param arg_str: The argument string (not including "!crates")
     """
     parser = argparse.ArgumentParser(prog="!crates", add_help=False)
@@ -50,28 +64,34 @@ def parse_arguments(channel: Channel, arg_str: str) -> Union[HelpCommand, CrateS
     def usage_error(*args, **kwargs):
         raise UsageSyntaxException()
 
-    parser.error = usage_error  # type: ignore
+    # parser.error = usage_error  # type: ignore
 
     # Converts "Date and time" into "date-and-time" which is the format used for category ids
-    category_formatter = lambda id: id.lower().strip().replace(' ', '-')
-    search_limit = lambda val: max(1, min(int(val), MAX_LIMIT))  # limits the val such that 0 < val <= MaxLimit
+    def category_formatter(cat: str): return cat.lower().strip().replace(' ', '-')
+
+    def search_limit(val: str): return max(1, min(int(val), MAX_LIMIT))  # limits the val such that 0 < val <= MaxLimit
 
     # For "!crates {args}"
-    parser.add_argument('-h', '--help', action='store_true', help='Prints this help message')
-    query_group = parser.add_mutually_exclusive_group(required=False)
-    query_group.add_argument('-n', '--name', default='', type=str.lower,
+    main_parser = subparsers.add_parser('main', add_help=False)
+    main_parser.add_argument('name', nargs='?', default='', type=str.lower,
                              help="The name of the crate to get information about")
-    query_group.add_argument('-s', '--search', default='', type=str.lower,
-                             help='Search for a crate instead of using its exact name')
-    parser.add_argument('-l', '--limit', default=5, type=search_limit,
-                        help='When not searching for a specific crate how many results should be shown? '
-                             '(max: ' + str(MAX_LIMIT) + ', default: %(default)s)')
-    parser.add_argument('-c', '--category', default='', type=category_formatter,
-                        help="Limit results to crates in this category")
-    parser.add_argument('-u', '--user', default='', type=str, help='Limit results by crate author')
-    parser.add_argument('-o', '--sort', choices=['alpha', 'downloads'], default='downloads', type=str.lower,
-                        help='Sort the results by alphabetical order or by number of downloads (default: %(default)s)')
-    parser.set_defaults(execute_action=handle_crates_route, crates_route=True)
+    main_parser.add_argument('-h', '--help', action='store_true', help='Prints this help message')
+    main_parser.set_defaults(execute_action=handle_exact_crate_route, route=SubCommand.EXACT)
+
+    # For !crates search {args}
+    search_parser = subparsers.add_parser('search', add_help=False, help='Sub-command to search for a crate')
+    search_parser.add_argument('search', nargs='?', default='', type=str.lower, help='The string to use for the search')
+    search_parser.add_argument('-h', '--help', action='store_true', help='Prints this help message')
+    search_parser.add_argument('-l', '--limit', default=5, type=search_limit,
+                               help='When not searching for a specific crate how many results should be shown? '
+                                    '(max: ' + str(MAX_LIMIT) + ', default: %(default)s)')
+    search_parser.add_argument('-c', '--category', default='', type=category_formatter,
+                               help="Limit results to crates in this category")
+    search_parser.add_argument('-u', '--user', default='', type=str, help='Limit results by crate author')
+    search_parser.add_argument('-o', '--sort', choices=['alpha', 'downloads'], default='downloads', type=str.lower,
+                               help='Sort the results by alphabetical order or by number of downloads '
+                                    '(default: %(default)s)')
+    search_parser.set_defaults(execute_action=handle_search_crates_route, route=SubCommand.SEARCH)
 
     # For "!crates categories {args}"
     category_parser = subparsers.add_parser('categories', add_help=False,
@@ -84,17 +104,42 @@ def parse_arguments(channel: Channel, arg_str: str) -> Union[HelpCommand, CrateS
                                       '(max:  ' + str(MAX_LIMIT) + ', default: %(default)s)')
     category_parser.add_argument('-s', '--sort', choices=['alpha', 'crates'], default='alpha', type=str.lower,
                                  help='Sort the result by alphabetical order or by number of crates in the category')
-    category_parser.set_defaults(execute_action=handle_categories_route, crates_route=False)
+    category_parser.set_defaults(execute_action=handle_categories_route, route=SubCommand.CATEGORIES)
 
     # TODO: For "!crates users {args}"
 
-    args = parser.parse_args(arg_str.split())
+    # We need to check if the first argument is "categories" or "search" otherwise we add "main" to get around an
+    # issue were argparse will complain that the name isn't one of the subparser names
+    split_args = arg_str.split()
+    if not split_args or (split_args[0] != "categories" and split_args[0] != "search"):
+        split_args.insert(0, "main")
 
-    # If the arguments show that help was requested then change the execute_action and add the help string
+    args = parser.parse_args(split_args)
+
+    # If the arguments show that help was requested then change the execute_action and add the correct help string
     if args.help:
         args.execute_action = handle_help_route
-        if args.crates_route:
-            args.help_string = parser.format_help()
+        if args.route == SubCommand.EXACT:
+            # Because we had to break parser up into main this help message needs to be manually typed to be useful
+            args.help_string = """
+*Usage: !crates [[name] | {search,categories}]*
+
+*Sub-Commands*:
+ {search,categories}
+   search              Search for a crate with conditions
+   categories          Get information about categories instead of crates
+   
+*Default Usage*:
+    usage: !crates [-h] [name]
+    
+    *Positional Arguments*:
+     name        The exact name of the crate to get information about (use search for non-exact name)
+    
+    *Optional Arguments*:
+     -h, --help  Prints this help message
+            """
+        elif args.route == SubCommand.SEARCH:
+            args.help_string = search_parser.format_help()
         else:
             args.help_string = category_parser.format_help()
 
@@ -102,12 +147,12 @@ def parse_arguments(channel: Channel, arg_str: str) -> Union[HelpCommand, CrateS
 
 
 def handle_help_route(channel: Channel, args: HelpCommand):
-    "This is called whenever the -h argument is invoked regardless of sub-command."
+    """This is called whenever the -h argument is invoked regardless of sub-command."""
     bot.post_message(channel, args.help_string)
 
 
 def get_user_id(username: str) -> int:
-    "Tries to get the users numerical id from their username. (Ex: BurntSushi -> 189). -1 on failure."
+    """"Tries to get the users numerical id from their username. (Ex: BurntSushi -> 189). -1 on failure."""
     url = f'{BASE_URL}/users/{username}'
     response = requests.get(url)
 
@@ -118,55 +163,101 @@ def get_user_id(username: str) -> int:
     user_data = json.loads(response.content)
 
     # If an error occurred then return with -1
-    if user_data.contains('errors'):
+    if 'errors' in user_data:
         return -1
 
     # Try to grab their id and return -1 if something goes wrong
     # (which it shouldn't at this point but the API is badly documented so I added this for safety)
     return int(user_data.get('user', {}).get('id', -1))
 
-def get_crate_result(crate: Dict[str, Union[str, int]]) -> Optional[CrateResult]:
+
+def convert_crate_result(crate: Dict[str, Union[str, int]]) -> Optional[CrateResult]:
     """Tries to convert a dictionary response from the api into a CrateResult. Returns None on error."""
     try:
-        return CrateResult(crate['name'], crate['downloads'], crate['homepage'], crate['description'])
-    except:
+        # Sometimes the homepage is null so we try to grab something else if possible otherwise default to crates.io
+        homepage = crate['homepage']
+        homepage = crate['repository'] if homepage is None else homepage
+        homepage = crate['documentation'] if homepage is None else homepage
+        homepage = "https://crates.io" if homepage is None else homepage
+
+        return CrateResult(crate['name'], crate['downloads'], homepage, crate['description'])
+    except KeyError:
         return None
 
-def get_crate_name_result(channel: Channel, name: str, params: dict) -> Optional[CrateResult]:
+
+def get_crate_name_result(channel: Channel, name: str) -> Optional[CrateResult]:
     """
     Get the result of searching for a specific crate by name
     :param channel: The channel to post any error messages in
     :param name: The name of the crate to search for
-    :param params: The parameters to pass to the request
     :return: The api response as a dictionary or None on error
     """
     url = f'{BASE_URL}/crates/{name}'
 
-    response = requests.get(url, params)
+    response = requests.get(url)
 
     # If there was a problem getting a response post a message to let the user know
     if response.status_code != requests.codes.ok:
         bot.post_message(channel, 'There was a problem getting a response.')
         return None
 
-    raw_crate_result = json.loads(response.content)
+    raw_crate_result = json.loads(response.content).get('crate', None)
 
-    if raw_crate_result.contains('errors'):
+    if raw_crate_result is None:
+        bot.post_message(channel, "There was an issue getting the crate information")
+        return None
+
+    if 'errors' in raw_crate_result:
         bot.post_message(channel, f"The requested crate {name} could not be found")
         return None
 
     # Convert the raw crate result to a CrateResult
-    crate = get_crate_result(raw_crate_result)
+    crate = convert_crate_result(raw_crate_result)
     if crate is None:
         bot.post_message(channel, "There was a problem getting information about the crate")
         return None
 
     return crate
 
+
+def get_crate_blocks(crate: CrateResult) -> List[Dict[str, Union[str, Dict[str, str], List[Dict[str, str]]]]]:
+    """Converts a crate into its block based message format for posting to slack"""
+    return [
+        {
+            'type': 'section',
+            'text': {
+                'type': 'mrkdwn',
+                'text': f'*<{crate.homepage}|{crate.name}>*\n{crate.description}'
+            },
+        },
+        {
+            'type': 'context',
+            'elements': [
+                {
+                    'type': 'plain_text',
+                    'text': f'Downloads: {crate.downloads}'
+                }
+            ]
+        },
+        {
+            'type': 'divider'
+        }
+    ]
+
+
+def handle_exact_crate_route(channel: Channel, args: ExactCrate):
+    """Handles what happens when a single crate is being searched for by exact name"""
+    crate = get_crate_name_result(channel, args.name)
+    if crate is None:
+        return
+
+    bot.post_message(channel, '', blocks=get_crate_blocks(crate))
+
+
 def get_crates_search_results(channel: Channel,
                               search: str,
                               params: dict,
-                              page: int = 1,) -> Optional[Tuple[List[CrateResult], int]]:
+                              page: int = 1, ) -> Optional[Tuple[List[CrateResult], int]]:
     """
     Gets a list of crates and the total number of results from the api based on input parameters and the page number
     :param channel: The channel to post any error messages to
@@ -176,7 +267,9 @@ def get_crates_search_results(channel: Channel,
     :return: (list of crates, total number of search results) or None if an error occurred
     """
     params['page'] = page
-    params['letter'] = search
+
+    if search:
+        params['letter'] = search
 
     url = BASE_URL + '/crates'
     response = requests.get(url, params)
@@ -193,7 +286,7 @@ def get_crates_search_results(channel: Channel,
     # Convert all of the crates to CrateResult
     crates = []
     for raw_crate in raw_crates:
-        crate = get_crate_result(raw_crate)
+        crate = convert_crate_result(raw_crate)
         if crate is None:
             bot.post_message(channel, "There was a problem getting information about a crate")
             return None
@@ -202,35 +295,9 @@ def get_crates_search_results(channel: Channel,
 
     return crates, total
 
-def handle_multiple_crate_search(channel: Channel, crates: List[dict]):
-    pass
-    # if not crates:
-    #     bot.post_message(channel, "No crates were found")
-    #     return None
 
-    # # Iterate over all of the crates or until limit is reached. Whichever comes first.
-    # for index in range(0, min(len(crates), args.limit) - 1):
-    #     crate = crates[index]
-    #     bot.post_message(channel, crate['name'])
-
-def handle_single_crate_search(channel: Channel, name: str, params: dict):
-    """
-    Handles the case of searching for a single crate by name
-    :param channel: The channel to post any results or errors to
-    :param name: The name of the crate to search for
-    :param params: Any additional parameters
-    """
-    crate = get_crate_name_result(channel, name, params)
-
-    block = {
-        'type': 'section',
-        'text': {
-            'type': 'mkdwn',
-            'text': crate.name
-        }
-    }
-
-def handle_crates_route(channel: Channel, args: CrateSearch):
+def handle_search_crates_route(channel: Channel, args: CrateSearch):
+    """Handles what happens when a crates are being searched for through multiple criteria"""
     # Generate the parameters to search with
     params = {'sort': args.sort}
 
@@ -248,12 +315,54 @@ def handle_crates_route(channel: Channel, args: CrateSearch):
 
         params['user_id'] = user_id
 
-    # Change execution based on whether we are searching for a single specific crate or multiple crates
-    if args.name:
-        handle_single_crate_search(channel, params)
-    else:
-        handle_multiple_crate_search(channel, params)
+    search_result = get_crates_search_results(channel, args.search, params)
+    if search_result is None:
+        return
+
+    crates, total = search_result
+
+    # No crates at all were found
+    if not crates:
+        bot.post_message(channel, "No crates were found")
+        return
+
+    # The beginning of the formatted response
+    blocks = [
+        {
+            'type': 'section',
+            'text': {
+                'type': 'mrkdwn',
+                'text': f'*Showing {min(args.limit, total)} of {total} results*'
+            },
+        },
+        {
+            'type': 'divider'
+        }
+    ]
+
+    # Iterate over all of the crates or until limit is reached. Whichever comes first.
+    page = 1
+    remaining = args.limit
+    while remaining > 0:
+        amt = range(0, min(len(crates), remaining))
+        for index in amt:
+            crate = crates[index]
+            blocks.extend(get_crate_blocks(crate))
+            remaining -= 1
+
+        page += 1
+        search_result = get_crates_search_results(channel, args.search, params, page)
+        if search_result is None or not search_result[0]:
+            break
+
+        crates, _ = search_result
+
+    bot.post_message(channel, '', blocks=blocks)
 
 
 def handle_categories_route(channel: Channel, args: CategorySearch):
     print("categories")
+
+
+def handle_users_route(channel: Channel, args: UserSearch):
+    print("users")

--- a/uqcsbot/scripts/crates.py
+++ b/uqcsbot/scripts/crates.py
@@ -60,7 +60,7 @@ def handle_crates(command: Command):
     args.execute_action(command.channel_id, args)  # type: ignore
 
 
-def parse_arguments(arg_str: str) -> Union[HelpCommand, CrateSearch, CategorySearch]:
+def parse_arguments(arg_str: str) -> argparse.Namespace:
     """
     Parses the arguments passed to the command
     :param arg_str: The argument string (not including "!crates")
@@ -195,7 +195,7 @@ def convert_crate_result(crate: Dict[str, Union[str, int]]) -> Optional[CrateRes
         homepage = crate['documentation'] if homepage is None else homepage
         homepage = "https://crates.io" if homepage is None else homepage
 
-        return CrateResult(crate['name'], crate['downloads'], homepage, crate['description'])
+        return CrateResult(crate['name'], crate['downloads'], homepage, crate['description'])  # type: ignore
     except KeyError:
         return None
 
@@ -321,7 +321,7 @@ def handle_search_crates_route(channel: Channel, args: CrateSearch):
 
     # If the user parameter is already a number use it as an id otherwise try to get the id
     if args.user.isdigit():
-        params['user_id'] = args.user
+        params['user_id'] = int(args.user)
     elif args.user:
         user_id = get_user_id(args.user)
         if user_id == -1:
@@ -501,6 +501,7 @@ def handle_categories_route(channel: Channel, args: CategorySearch):
         display_specific_category(channel, args)
     else:
         display_all_categories(channel, args)
+
 
 def get_user(channel: Channel, username: str) -> Optional[UserResult]:
     """Gets a UserResult by querying the api for the given username. None on error."""

--- a/uqcsbot/scripts/crates.py
+++ b/uqcsbot/scripts/crates.py
@@ -39,18 +39,22 @@ CategoryResult = NamedTuple('CategoryResult', [('name', str), ('description', st
 # Named tuple for a user that was found in a search
 UserResult = NamedTuple('UserResult', [('id', int), ('username', str), ('name', str), ('avatar', str), ('url', str)])
 
+
 class SlackBlock(ABC):
     """
     Abstract class for a formatted slack block
     (follows the conventions from https://api.slack.com/reference/messaging/blocks)
     """
+
     @abstractmethod
     def get_formatted_block(self) -> Dict[str, str]:
         """Gets the dictionary which maps the required properties for the given block"""
         pass
 
+
 class ImageBlock(SlackBlock):
     """SlackBlock that represents an image block (contains an image url and alternate text for that image)"""
+
     def __init__(self, url: str, alt_text: str):
         self.url = url
         self.alt_text = alt_text
@@ -62,10 +66,11 @@ class ImageBlock(SlackBlock):
             'alt_text': self.alt_text
         }
 
+
 class TextBlock(SlackBlock):
     """SlackBlock that represents a text block (contains an image url and alternate text for that image)"""
 
-    def __init__(self, text: str, markdown: bool=True):
+    def __init__(self, text: str, markdown: bool = True):
         self.text = text
         self.markdown = markdown
 
@@ -74,6 +79,7 @@ class TextBlock(SlackBlock):
             'type': 'mrkdwn' if self.markdown else 'plain_text',
             'text': self.text
         }
+
 
 class SubCommand(Enum):
     """Distinguishes the type of sub command that was invoked"""
@@ -271,7 +277,7 @@ def get_crate_name_result(channel: Channel, name: str) -> Optional[CrateResult]:
     return crate
 
 
-def create_slack_section_block(text: TextBlock, accessory: Optional[SlackBlock]=None) -> dict:
+def create_slack_section_block(text: TextBlock, accessory: Optional[SlackBlock] = None) -> dict:
     """
     Creates a "section block" as described in the slack documentation here:
     https://api.slack.com/reference/messaging/blocks#section
@@ -297,6 +303,7 @@ def create_slack_context_block(elements: List[SlackBlock]) -> dict:
         'elements': [element.get_formatted_block() for element in elements],
     }
 
+
 def create_slack_divider_block() -> Dict[str, str]:
     """
     Returns a "divider block" as described in the slack documentation here:
@@ -305,6 +312,7 @@ def create_slack_divider_block() -> Dict[str, str]:
     return {
         'type': 'divider'
     }
+
 
 def get_crate_blocks(crate: CrateResult) -> List[Dict[str, Union[str, Dict[str, str], List[Dict[str, str]]]]]:
     """Converts a crate into its block based message format for posting to slack"""

--- a/uqcsbot/scripts/crates.py
+++ b/uqcsbot/scripts/crates.py
@@ -314,7 +314,7 @@ def create_slack_divider_block() -> Dict[str, str]:
     }
 
 
-def get_crate_blocks(crate: CrateResult) -> List[Union[dict, List[Dict[str, str]]]]:
+def get_crate_blocks(crate: CrateResult) -> List[dict]:
     """Converts a crate into its block based message format for posting to slack"""
     return [
         create_slack_section_block(TextBlock(f'*<{crate.homepage}|{crate.name}>*\n{crate.description}')),

--- a/uqcsbot/scripts/crates.py
+++ b/uqcsbot/scripts/crates.py
@@ -1,0 +1,259 @@
+import argparse
+import json
+from typing import NamedTuple, Union, Optional, List, Dict, Tuple
+
+import requests
+
+from uqcsbot import bot, Command
+from uqcsbot.api import Channel
+from uqcsbot.utils.command_utils import loading_status, UsageSyntaxException
+
+BASE_URL = "https://crates.io/api/v1"
+MAX_LIMIT = 15  # The maximum number of search results from one call to the command
+
+# NamedTuple for the case that the argparse finds a -h flag
+HelpCommand = NamedTuple('HelpCommand', [('help_string', str)])
+
+# NamedTuple for the default command that deals with searching for specific crates
+CrateSearch = NamedTuple('CrateSearch',
+                         [('name', str), ('limit', int), ('category', str), ('user', str), ('sort', str),
+                          ('search', str)])
+
+# NamedTuple for the default categories sub-command that deals with searching for categories
+CategorySearch = NamedTuple('CategorySearch', [('name', str), ('limit', int), ('sort', str)])
+
+# Named tuple for a crate that was found in a search
+CrateResult = NamedTuple('CrateResult', [('name', str), ('downloads', int), ('homepage', str), ('description', str)])
+
+@bot.on_command('crates')
+@loading_status
+def handle_crates(command: Command):
+    """
+    `!crates `
+            - Get information about crates from crates.io
+    """
+    args = parse_arguments(command.channel_id, command.arg if command.has_arg() else '')
+
+    args.execute_action(command.channel_id, args)  # type: ignore
+
+
+def parse_arguments(channel: Channel, arg_str: str) -> Union[HelpCommand, CrateSearch, CategorySearch]:
+    """
+    Parses the arguments passed to the command
+    :param channel: The channel to post help to (help message needs access to parser)
+    :param arg_str: The argument string (not including "!crates")
+    """
+    parser = argparse.ArgumentParser(prog="!crates", add_help=False)
+    subparsers = parser.add_subparsers()
+
+    # Change the parsers default on error behaviour
+    def usage_error(*args, **kwargs):
+        raise UsageSyntaxException()
+
+    parser.error = usage_error  # type: ignore
+
+    # Converts "Date and time" into "date-and-time" which is the format used for category ids
+    category_formatter = lambda id: id.lower().strip().replace(' ', '-')
+    search_limit = lambda val: max(1, min(int(val), MAX_LIMIT))  # limits the val such that 0 < val <= MaxLimit
+
+    # For "!crates {args}"
+    parser.add_argument('-h', '--help', action='store_true', help='Prints this help message')
+    query_group = parser.add_mutually_exclusive_group(required=False)
+    query_group.add_argument('-n', '--name', default='', type=str.lower,
+                             help="The name of the crate to get information about")
+    query_group.add_argument('-s', '--search', default='', type=str.lower,
+                             help='Search for a crate instead of using its exact name')
+    parser.add_argument('-l', '--limit', default=5, type=search_limit,
+                        help='When not searching for a specific crate how many results should be shown? '
+                             '(max: ' + str(MAX_LIMIT) + ', default: %(default)s)')
+    parser.add_argument('-c', '--category', default='', type=category_formatter,
+                        help="Limit results to crates in this category")
+    parser.add_argument('-u', '--user', default='', type=str, help='Limit results by crate author')
+    parser.add_argument('-o', '--sort', choices=['alpha', 'downloads'], default='downloads', type=str.lower,
+                        help='Sort the results by alphabetical order or by number of downloads (default: %(default)s)')
+    parser.set_defaults(execute_action=handle_crates_route, crates_route=True)
+
+    # For "!crates categories {args}"
+    category_parser = subparsers.add_parser('categories', add_help=False,
+                                            help='Sub-command to get information about categories instead of crates')
+    category_parser.add_argument('-h', '--help', action='store_true', help='Prints this help message')
+    category_parser.add_argument('-n', '--name', default='', type=category_formatter,
+                                 help='Specify a specific category to get more information about it')
+    category_parser.add_argument('-l', '--limit', default=5, type=search_limit,
+                                 help=f'When not searching for a specific category how many results should be shown? '
+                                      '(max:  ' + str(MAX_LIMIT) + ', default: %(default)s)')
+    category_parser.add_argument('-s', '--sort', choices=['alpha', 'crates'], default='alpha', type=str.lower,
+                                 help='Sort the result by alphabetical order or by number of crates in the category')
+    category_parser.set_defaults(execute_action=handle_categories_route, crates_route=False)
+
+    # TODO: For "!crates users {args}"
+
+    args = parser.parse_args(arg_str.split())
+
+    # If the arguments show that help was requested then change the execute_action and add the help string
+    if args.help:
+        args.execute_action = handle_help_route
+        if args.crates_route:
+            args.help_string = parser.format_help()
+        else:
+            args.help_string = category_parser.format_help()
+
+    return args
+
+
+def handle_help_route(channel: Channel, args: HelpCommand):
+    "This is called whenever the -h argument is invoked regardless of sub-command."
+    bot.post_message(channel, args.help_string)
+
+
+def get_user_id(username: str) -> int:
+    "Tries to get the users numerical id from their username. (Ex: BurntSushi -> 189). -1 on failure."
+    url = f'{BASE_URL}/users/{username}'
+    response = requests.get(url)
+
+    # If there was a problem getting a response return -1
+    if response.status_code != requests.codes.ok:
+        return -1
+
+    user_data = json.loads(response.content)
+
+    # If an error occurred then return with -1
+    if user_data.contains('errors'):
+        return -1
+
+    # Try to grab their id and return -1 if something goes wrong
+    # (which it shouldn't at this point but the API is badly documented so I added this for safety)
+    return int(user_data.get('user', {}).get('id', -1))
+
+def get_crate_result(crate: Dict[str, Union[str, int]]) -> Optional[CrateResult]:
+    """Tries to convert a dictionary response from the api into a CrateResult. Returns None on error."""
+    try:
+        return CrateResult(crate['name'], crate['downloads'], crate['homepage'], crate['description'])
+    except:
+        return None
+
+def get_crate_name_result(channel: Channel, name: str, params: dict) -> Optional[CrateResult]:
+    """
+    Get the result of searching for a specific crate by name
+    :param channel: The channel to post any error messages in
+    :param name: The name of the crate to search for
+    :param params: The parameters to pass to the request
+    :return: The api response as a dictionary or None on error
+    """
+    url = f'{BASE_URL}/crates/{name}'
+
+    response = requests.get(url, params)
+
+    # If there was a problem getting a response post a message to let the user know
+    if response.status_code != requests.codes.ok:
+        bot.post_message(channel, 'There was a problem getting a response.')
+        return None
+
+    raw_crate_result = json.loads(response.content)
+
+    if raw_crate_result.contains('errors'):
+        bot.post_message(channel, f"The requested crate {name} could not be found")
+        return None
+
+    # Convert the raw crate result to a CrateResult
+    crate = get_crate_result(raw_crate_result)
+    if crate is None:
+        bot.post_message(channel, "There was a problem getting information about the crate")
+        return None
+
+    return crate
+
+def get_crates_search_results(channel: Channel,
+                              search: str,
+                              params: dict,
+                              page: int = 1,) -> Optional[Tuple[List[CrateResult], int]]:
+    """
+    Gets a list of crates and the total number of results from the api based on input parameters and the page number
+    :param channel: The channel to post any error messages to
+    :param search: The string to search for
+    :param params: The parameters dictionary that gets passed to requests.get
+    :param page: The page of the results to get from
+    :return: (list of crates, total number of search results) or None if an error occurred
+    """
+    params['page'] = page
+    params['letter'] = search
+
+    url = BASE_URL + '/crates'
+    response = requests.get(url, params)
+
+    # If there was a problem getting a response post a message to let the user know
+    if response.status_code != requests.codes.ok:
+        bot.post_message(channel, 'There was a problem getting a response.')
+        return None
+
+    crates_results = json.loads(response.content)
+    raw_crates = crates_results.get('crates', [])
+    total = crates_results.get('meta', {}).get('total', 0)
+
+    # Convert all of the crates to CrateResult
+    crates = []
+    for raw_crate in raw_crates:
+        crate = get_crate_result(raw_crate)
+        if crate is None:
+            bot.post_message(channel, "There was a problem getting information about a crate")
+            return None
+
+        crates.append(crate)
+
+    return crates, total
+
+def handle_multiple_crate_search(channel: Channel, crates: List[dict]):
+    pass
+    # if not crates:
+    #     bot.post_message(channel, "No crates were found")
+    #     return None
+
+    # # Iterate over all of the crates or until limit is reached. Whichever comes first.
+    # for index in range(0, min(len(crates), args.limit) - 1):
+    #     crate = crates[index]
+    #     bot.post_message(channel, crate['name'])
+
+def handle_single_crate_search(channel: Channel, name: str, params: dict):
+    """
+    Handles the case of searching for a single crate by name
+    :param channel: The channel to post any results or errors to
+    :param name: The name of the crate to search for
+    :param params: Any additional parameters
+    """
+    crate = get_crate_name_result(channel, name, params)
+
+    block = {
+        'type': 'section',
+        'text': {
+            'type': 'mkdwn',
+            'text': crate.name
+        }
+    }
+
+def handle_crates_route(channel: Channel, args: CrateSearch):
+    # Generate the parameters to search with
+    params = {'sort': args.sort}
+
+    if args.category:
+        params['category'] = args.category
+
+    # If the user parameter is already a number use it as an id otherwise try to get the id
+    if args.user.isdigit():
+        params['user_id'] = args.user
+    elif args.user:
+        user_id = get_user_id(args.user)
+        if user_id == -1:
+            bot.post_message(channel, f'The username {args.user} could not be resolved')
+            return
+
+        params['user_id'] = user_id
+
+    # Change execution based on whether we are searching for a single specific crate or multiple crates
+    if args.name:
+        handle_single_crate_search(channel, params)
+    else:
+        handle_multiple_crate_search(channel, params)
+
+
+def handle_categories_route(channel: Channel, args: CategorySearch):
+    print("categories")

--- a/uqcsbot/scripts/crates.py
+++ b/uqcsbot/scripts/crates.py
@@ -51,11 +51,12 @@ class SubCommand(Enum):
 @loading_status
 def handle_crates(command: Command):
     """
-    `!crates `
+    `!crates [-h] [[name] | {search,categories,users}]`
             - Get information about crates from crates.io
     """
     args = parse_arguments(command.arg if command.has_arg() else '')
 
+    # Executes the function that was stored by the arg parser depending on which sub-command was used
     args.execute_action(command.channel_id, args)  # type: ignore
 
 
@@ -112,7 +113,7 @@ def parse_arguments(arg_str: str) -> Union[HelpCommand, CrateSearch, CategorySea
                                  help='Sort the result by alphabetical order or by number of crates in the category')
     category_parser.set_defaults(execute_action=handle_categories_route, route=SubCommand.CATEGORIES)
 
-    # TODO: For "!crates users {args}"
+    # For "!crates users {args}"
     users_parser = subparsers.add_parser('user', add_help=False,
                                          help='Sub-command to get information about a username')
     users_parser.add_argument('username', help='The users username')
@@ -441,6 +442,7 @@ def display_all_categories(channel: Channel, args: CategorySearch):
 
 
 def display_specific_category(channel: Channel, args: CategorySearch):
+    """Displays a single category in more detail"""
     # Get the categories
     url = BASE_URL + f'/categories/{args.name}'
     response = requests.get(url)
@@ -500,9 +502,6 @@ def handle_categories_route(channel: Channel, args: CategorySearch):
     else:
         display_all_categories(channel, args)
 
-
-# UserResult = NamedTuple('UserResult', [('id', int), ('username', str), ('name', str), ('avatar', str), ('url', str)])
-
 def get_user(channel: Channel, username: str) -> Optional[UserResult]:
     """Gets a UserResult by querying the api for the given username. None on error."""
     url = f'{BASE_URL}/users/{username}'
@@ -528,6 +527,7 @@ def get_user(channel: Channel, username: str) -> Optional[UserResult]:
 
 
 def handle_users_route(channel: Channel, args: UserSearch):
+    """Displays information about a user from their username"""
     user = get_user(channel, args.username)
 
     # Error occurred
@@ -535,9 +535,9 @@ def handle_users_route(channel: Channel, args: UserSearch):
         return
 
     # Begin formatting the message
-    text = f'*{user.username}:*\n\tID: {user.id}\n\tName: {user.id}\n\t'
+    text = f'*{user.username}:*\n\t*ID*: {user.id}\n\t*Name:* {user.name}\n\t'
     if user.url:
-        text += f'Homepage: {user.url}'
+        text += f'*Homepage:* {user.url}'
 
     blocks = [
         {

--- a/uqcsbot/scripts/crates.py
+++ b/uqcsbot/scripts/crates.py
@@ -321,14 +321,14 @@ def handle_search_crates_route(channel: Channel, args: CrateSearch):
 
     # If the user parameter is already a number use it as an id otherwise try to get the id
     if args.user.isdigit():
-        params['user_id'] = int(args.user)
+        params['user_id'] = args.user
     elif args.user:
         user_id = get_user_id(args.user)
         if user_id == -1:
             bot.post_message(channel, f'The username {args.user} could not be resolved')
             return
 
-        params['user_id'] = user_id
+        params['user_id'] = str(user_id)
 
     search_result = get_crates_search_results(channel, args.search, params)
     if search_result is None:
@@ -385,7 +385,7 @@ def get_category_page(channel: Channel, sort: str, page: int) -> Tuple[Optional[
     """
     # Get the categories
     url = BASE_URL + '/categories'
-    response = requests.get(url, {'sort': sort, 'page': page})
+    response = requests.get(url, {'sort': sort, 'page': page})  # type: ignore
 
     if response.status_code != requests.codes.ok:
         bot.post_message(channel, 'There was a problem getting the list of categories')

--- a/uqcsbot/scripts/crates.py
+++ b/uqcsbot/scripts/crates.py
@@ -314,7 +314,7 @@ def create_slack_divider_block() -> Dict[str, str]:
     }
 
 
-def get_crate_blocks(crate: CrateResult) -> List[Dict[str, Union[str, Dict[str, str], List[Dict[str, str]]]]]:
+def get_crate_blocks(crate: CrateResult) -> List[Union[dict, List[Dict[str, str]]]]:
     """Converts a crate into its block based message format for posting to slack"""
     return [
         create_slack_section_block(TextBlock(f'*<{crate.homepage}|{crate.name}>*\n{crate.description}')),


### PR DESCRIPTION
Adds a command !crates which does a whole bunch of stuff related to crates.io.

To summarise, it can search crates by exact name or it can return a list of crates narrowed down by a search term, category and author. It can also return a list of all category names and give more in depth detail about a category. Finally, it can return publicly available information about a user. Examples of all of these scenarios below.

![1](https://user-images.githubusercontent.com/24851062/54458575-0a0dbf00-47b0-11e9-8795-5fcbab86fe9b.PNG)
![2](https://user-images.githubusercontent.com/24851062/54458576-0a0dbf00-47b0-11e9-9960-7b4ac0ee5532.PNG)
![3](https://user-images.githubusercontent.com/24851062/54458577-0aa65580-47b0-11e9-99cc-b828c640910f.PNG)
![4](https://user-images.githubusercontent.com/24851062/54458578-0aa65580-47b0-11e9-8dc1-1ff1c875a348.PNG)
![5](https://user-images.githubusercontent.com/24851062/54458579-0aa65580-47b0-11e9-9087-16df6e354ac5.PNG)
![6](https://user-images.githubusercontent.com/24851062/54458582-0b3eec00-47b0-11e9-8be4-f9a23cc03900.PNG)
![7](https://user-images.githubusercontent.com/24851062/54458584-0b3eec00-47b0-11e9-81f9-f81e81e17271.PNG)
