### PR TITLE
Naive fix for hoogle. Strip html and formatting

### DIFF
--- a/uqcsbot/scripts/hoogle.py
+++ b/uqcsbot/scripts/hoogle.py
@@ -1,4 +1,5 @@
 from uqcsbot import bot, Command
+from uqcsbot.utils.command_utils import loading_status
 import requests
 import json
 import html
@@ -22,6 +23,7 @@ def pretty_hoogle_result(result: dict, is_verbose: bool) -> str:
 
 
 @bot.on_command("hoogle")
+@loading_status
 def handle_hoogle(command: Command):
     '''
     `!hoogle [-v] [--verbose] <TYPE_SIGNATURE>` - Queries the Hoogle Haskell API search engine,

--- a/uqcsbot/scripts/hoogle.py
+++ b/uqcsbot/scripts/hoogle.py
@@ -2,7 +2,7 @@ from uqcsbot import bot, Command
 import requests
 import json
 import html
-
+import re
 
 def get_endpoint(type_sig: str) -> str:
     unescaped = html.unescape(type_sig)
@@ -11,9 +11,9 @@ def get_endpoint(type_sig: str) -> str:
 
 
 def pretty_hoogle_result(result: dict, is_verbose: bool) -> str:
-    url = result['location']
-    type_sig = result['self']
-    docs = result['docs']
+    url = result['url']
+    type_sig = re.sub('<[^<]+?>', '', result['item'])
+    docs = re.sub('<[^<]+?>', '', result['docs']).replace('\n',' ').replace('&gt;&gt;&gt;','\n>')
 
     if is_verbose:
         return f"`{type_sig}` <{url}|link>\n{docs}"
@@ -53,7 +53,7 @@ def handle_hoogle(command: Command):
         bot.post_message(command.channel_id, "Problem fetching data")
         return
 
-    results = json.loads(http_response.content).get('results', [])
+    results = json.loads(http_response.content)
 
     if len(results) == 0:
         bot.post_message(command.channel_id, "No results found")


### PR DESCRIPTION
Fixes #433

For reference, the response format directly returns a list of dicts now. Example dict:
```
{"url":"https://hackage.haskell.org/package/base/docs/Prelude.html#v:const","module":{"url":"https://hackage.haskell.org/package/base/docs/Prelude.html","name":"Prelude"},"package":{"url":"https://hackage.haskell.org/package/base","name":"base"},"item":"<span class=name><s0>const</s0></span> :: a -&gt; b -&gt; a","type":"","docs":"<tt>const x</tt> is a unary function which evaluates to <tt>x</tt> for\nall inputs.\n\n<pre>\n&gt;&gt;&gt; const 42 \"hello\"\n42\n</pre>\n\n<pre>\n&gt;&gt;&gt; map (const 42) [0..3]\n[42,42,42,42]\n</pre>\n"}
```

The responses now also contain HTML markup. It's trivial to strip from the type sig but less so from the docs segment without the formatting for the docs section being a little awkward.

![image](https://user-images.githubusercontent.com/30421879/57667070-a84dc200-7645-11e9-9730-a8a48a30c3cb.png)

![image](https://user-images.githubusercontent.com/30421879/57667101-b996ce80-7645-11e9-979e-b07b9d114c20.png)