### PR TITLE
Create !crisis, !mentalhealth and !emergency commands

### DIFF
--- a/test/test_crisis.py
+++ b/test/test_crisis.py
@@ -1,5 +1,6 @@
 from test.conftest import MockUQCSBot, TEST_CHANNEL_ID
 
+
 def test_crisis_keyword(uqcsbot: MockUQCSBot):
     '''
     Ensure !crisis returns the intended resource
@@ -18,6 +19,7 @@ def test_mentalhealth_keyword(uqcsbot: MockUQCSBot):
     messages = uqcsbot.test_messages.get(TEST_CHANNEL_ID, [])
     assert len(messages) == 2
     assert "campus security" in messages[-1]['text'].lower()
+
 
 def test_emergency_keyword(uqcsbot: MockUQCSBot):
     '''

--- a/test/test_crisis.py
+++ b/test/test_crisis.py
@@ -1,0 +1,29 @@
+from test.conftest import MockUQCSBot, TEST_CHANNEL_ID
+
+def test_crisis_keyword(uqcsbot: MockUQCSBot):
+    '''
+    Ensure !crisis returns the intended resource
+    '''
+    uqcsbot.post_message(TEST_CHANNEL_ID, '!crisis')
+    messages = uqcsbot.test_messages.get(TEST_CHANNEL_ID, [])
+    assert len(messages) == 2
+    assert "campus security" in messages[-1]['text'].lower()
+
+
+def test_mentalhealth_keyword(uqcsbot: MockUQCSBot):
+    '''
+    Ensure !mentalhealth also returns the intended resource
+    '''
+    uqcsbot.post_message(TEST_CHANNEL_ID, '!mentalhealth')
+    messages = uqcsbot.test_messages.get(TEST_CHANNEL_ID, [])
+    assert len(messages) == 2
+    assert "campus security" in messages[-1]['text'].lower()
+
+def test_emergency_keyword(uqcsbot: MockUQCSBot):
+    '''
+    Ensure !emergency also does the needful
+    '''
+    uqcsbot.post_message(TEST_CHANNEL_ID, '!emergency')
+    messages = uqcsbot.test_messages.get(TEST_CHANNEL_ID, [])
+    assert len(messages) == 2
+    assert "campus security" in messages[-1]['text'].lower()

--- a/uqcsbot/scripts/crisis.py
+++ b/uqcsbot/scripts/crisis.py
@@ -1,0 +1,20 @@
+from uqcsbot import bot, Command
+
+RESPONSE = """*Mental health/crisis resources*
+24/7 UQ Counselling and Crisis Line: 1300 851 998
+Campus Security (emergency): 07 3365 3333
+Campus Security (non-emergency): 07 3365 1234
+Counselling Services: https://www.uq.edu.au/student-services/counselling-services
+UQ Psychology Clinic: https://clinic.psychology.uq.edu.au/therapies-and-services
+UQ resources: https://about.uq.edu.au/campaigns-and-initiatives/mental-health"""
+
+
+@bot.on_command("crisis")
+@bot.on_command("mentalhealth")
+@bot.on_command("emergency")
+def handle_crisis(command: Command):
+    '''
+    `!crisis`, `!mentalhealth` or `emergency` - Get a list of emergency resources.
+    '''
+
+    bot.post_message(command.channel_id, RESPONSE)


### PR DESCRIPTION
Re-merge of #435 after Nick did some stuff with the tests. Content is identical.

All are aliases for the same thing - provide a list of crisis resources for
quick reference.