### PR TITLE
Increase `!parking` robustness

### DIFF
--- a/test/parking.html
+++ b/test/parking.html
@@ -65,86 +65,114 @@
     <tr>
 	<td class='zone'>P1</td>
 	<td class=''></td>
-	<td class='casual nearlyfull
-'>NEARLY FULL</td>
+	<td class='casual 32
+'>32
+</td>
 </tr>
 <tr>
 	<td class='zone'>P2</td>
 	<td class=''></td>
-	<td class='casual full
-'>FULL</td>
+	<td class='casual nearly
+full
+'>NEARLY
+FULL
+</td>
 </tr>
 <tr>
 	<td class='zone'>P3</td>
-	<td class='permit 266
-'>266</td>
+	<td class='permit 193
+'>193
+</td>
 	<td class=''></td>
 </tr>
 <tr>
 	<td class='zone'>P4</td>
-	<td class='permit 115
-'>115</td>
+	<td class='permit nearly
+full
+'>NEARLY
+FULL
+</td>
 	<td class=''></td>
 </tr>
 <tr>
 	<td class='zone'>P6</td>
 	<td class=''></td>
-	<td class='casual full
-'>FULL</td>
+	<td class='casual 6
+'>6
+</td>
 </tr>
 <tr>
 	<td class='zone'>P7</td>
 	<td class=''></td>
 	<td class='casual full
-'>FULL</td>
+'>FULL
+</td>
+</tr>
+<tr>
+	<td class='zone'>P7 UC</td>
+	<td class=''></td>
+	<td class='casual 39
+'>39
+</td>
 </tr>
 <tr>
 	<td class='zone'>P8 L1</td>
 	<td class=''></td>
-	<td class='casual nearlyfull
-'>NEARLY FULL</td>
+	<td class='casual 58
+'>58
+</td>
 </tr>
 <tr>
 	<td class='zone'>P8 L2</td>
 	<td class=''></td>
-	<td class='casual full
-'>FULL</td>
+	<td class='casual 29
+'>29
+</td>
 </tr>
 <tr>
 	<td class='zone'>P9</td>
 	<td class=''></td>
-	<td class='casual full
-'>FULL</td>
+	<td class='casual 21
+'>21
+</td>
 </tr>
 <tr>
 	<td class='zone'>P10</td>
 	<td class=''></td>
-	<td class='casual 204
-'>204</td>
+	<td class='casual 167
+'>167
+</td>
 </tr>
 <tr>
 	<td class='zone'>P11 L1</td>
-	<td class='permit nearlyfull
-'>NEARLY FULL</td>
+	<td class='permit 23
+'>23
+</td>
 	<td class=''></td>
 </tr>
 <tr>
 	<td class='zone'>P11 L2</td>
-	<td class='permit 61
-'>61</td>
+	<td class='permit nearly
+full
+'>NEARLY
+FULL
+</td>
 	<td class=''></td>
 </tr>
 <tr>
 	<td class='zone'>P11 L3</td>
 	<td class=''></td>
-	<td class='casual full
-'>FULL</td>
+	<td class='casual nearly
+full
+'>NEARLY
+FULL
+</td>
 </tr>
 
 
     </table>
 
-    <p>Data last updated: Thursday, 9:01 AM</p>
+    <p>Data last updated: Monday, 3:23 PM</p>
 
 	<p><a href='http://www.pf.uq.edu.au/parking/availability/'>Map view</a></p>
 	

--- a/test/test_parking.py
+++ b/test/test_parking.py
@@ -24,16 +24,17 @@ def test_parking(uqcsbot: MockUQCSBot):
     assert len(messages) == 2
     assert (messages[-1]['text'] ==
             "*Available Parks at UQ St. Lucia*\n"
-            "Few Carparks Availible in P1 - Warehouse (14P Daily)\n"
-            "No Carparks Availible in P2 - Space Bank (14P Daily)\n"
-            "No Carparks Availible in P6 - Hartley Teakle (14P Hourly)\n"
+            "32 Carparks Availible in P1 - Warehouse (14P Daily)\n"
+            "Few Carparks Availible in P2 - Space Bank (14P Daily)\n"
+            "6 Carparks Availible in P6 - Hartley Teakle (14P Hourly)\n"
             "No Carparks Availible in P7 - DustBowl (14P Daily)\n"
-            "Few Carparks Availible in P8 - Athletics Basement (14P Daily)\n"
-            "No Carparks Availible in P8 - Athletics Roof (14P Daily)\n"
-            "No Carparks Availible in P9 - Boatshed (14P Daily)\n"
-            "204 Carparks Availible in P10 - UQ Centre & "
-            "Playing Fields (14P Daily/14P Daily Capped)\n"
-            "No Carparks Availible in P11 - Conifer Knoll Roof (14P Daily Restricted)")
+            "39 Carparks Availible in P7 - Keith Street (14P Daily Capped)\n"
+            "58 Carparks Availible in P8 - Athletics Basement (14P Daily)\n"
+            "29 Carparks Availible in P8 - Athletics Roof (14P Daily)\n"
+            "21 Carparks Availible in P9 - Boatshed (14P Daily)\n"
+            "167 Carparks Availible in P10 - UQ Centre"
+            " & Playing Fields (14P Daily/14P Daily Capped)\n"
+            "Few Carparks Availible in P11 - Conifer Knoll Roof (14P Daily Restricted)")
 
 
 @patch("uqcsbot.scripts.parking.get_pf_parking_data", new=mocked_get_pf_parking_data)
@@ -46,17 +47,18 @@ def test_parking_all(uqcsbot: MockUQCSBot):
     assert len(messages) == 2
     assert (messages[-1]['text'] ==
             "*Available Parks at UQ St. Lucia*\n"
-            "Few Carparks Availible in P1 - Warehouse (14P Daily)\n"
-            "No Carparks Availible in P2 - Space Bank (14P Daily)\n"
-            "266 Carparks Availible in P3 - Multi-Level West (Staff)\n"
-            "115 Carparks Availible in P4 - Multi-Level East (Staff)\n"
-            "No Carparks Availible in P6 - Hartley Teakle (14P Hourly)\n"
+            "32 Carparks Availible in P1 - Warehouse (14P Daily)\n"
+            "Few Carparks Availible in P2 - Space Bank (14P Daily)\n"
+            "193 Carparks Availible in P3 - Multi-Level West (Staff)\n"
+            "Few Carparks Availible in P4 - Multi-Level East (Staff)\n"
+            "6 Carparks Availible in P6 - Hartley Teakle (14P Hourly)\n"
             "No Carparks Availible in P7 - DustBowl (14P Daily)\n"
-            "Few Carparks Availible in P8 - Athletics Basement (14P Daily)\n"
-            "No Carparks Availible in P8 - Athletics Roof (14P Daily)\n"
-            "No Carparks Availible in P9 - Boatshed (14P Daily)\n"
-            "204 Carparks Availible in P10 - UQ Centre & "
-            "Playing Fields (14P Daily/14P Daily Capped)\n"
-            "Few Carparks Availible in P11 - Conifer Knoll Lower (Staff)\n"
-            "61 Carparks Availible in P11 - Conifer Knoll Upper (Staff)\n"
-            "No Carparks Availible in P11 - Conifer Knoll Roof (14P Daily Restricted)")
+            "39 Carparks Availible in P7 - Keith Street (14P Daily Capped)\n"
+            "58 Carparks Availible in P8 - Athletics Basement (14P Daily)\n"
+            "29 Carparks Availible in P8 - Athletics Roof (14P Daily)\n"
+            "21 Carparks Availible in P9 - Boatshed (14P Daily)\n"
+            "167 Carparks Availible in P10 - UQ Centre"
+            " & Playing Fields (14P Daily/14P Daily Capped)\n"
+            "23 Carparks Availible in P11 - Conifer Knoll Lower (Staff)\n"
+            "Few Carparks Availible in P11 - Conifer Knoll Upper (Staff)\n"
+            "Few Carparks Availible in P11 - Conifer Knoll Roof (14P Daily Restricted)")

--- a/uqcsbot/scripts/parking.py
+++ b/uqcsbot/scripts/parking.py
@@ -3,7 +3,7 @@ from uqcsbot.utils.command_utils import loading_status
 from typing import Tuple
 
 import requests
-from bs4 import BeautifulSoup
+from bs4 import BeautifulSoup as Soup
 
 
 def get_pf_parking_data() -> Tuple[int, str]:
@@ -53,10 +53,10 @@ def handle_parking(command: Command) -> None:
         return fill
 
     # find parks
-    table = BeautifulSoup(data, 'html.parser').find("table", attrs={"id": "parkingAvailability"})
+    table = Soup(data, "html.parser").find("table", attrs={"id": "parkingAvailability"})
     rows = table.find_all("tr")[1:]
     # split and join for single space whitespace
-    areas = [[" ".join(i.get_text().strip().split()) for i in j.find_all("td")] for j in rows]
+    areas = [[" ".join(i.get_text().split()) for i in j.find_all("td")] for j in rows]
 
     for area in areas:
         if area[2]:


### PR DESCRIPTION
UQ Properties and Facilities seem to like randomly changing the amount of whitespace on their parking availability webpage (see changes to `tests/parking.html`). This pull should allow `!parking` to work no matter how much whitespace they wish to add/remove.