### PR TITLE
Update emojify.py

### DIFF
--- a/uqcsbot/scripts/emojify.py
+++ b/uqcsbot/scripts/emojify.py
@@ -131,6 +131,7 @@ def handle_emojify(command: Command):
     # revert HTML conversions
     text = text.replace("&AMP;", "&")
     text = text.replace("&GT;", ">")
+    text = text.replace("&LT;", "<")
 
     lexicon = {}
     for character in set(text+'…'):

--- a/uqcsbot/scripts/emojify.py
+++ b/uqcsbot/scripts/emojify.py
@@ -129,9 +129,9 @@ def handle_emojify(command: Command):
     if command.has_arg():
         text = command.arg.upper()
     # revert HTML conversions
-    text = text.replace("&AMP;", "&")
     text = text.replace("&GT;", ">")
     text = text.replace("&LT;", "<")
+    text = text.replace("&AMP;", "&")
 
     lexicon = {}
     for character in set(text+'…'):


### PR DESCRIPTION
`<` will be emojified correctly (though no emoji currently exists).
`!emojify &gt;` will now return four emoji, not one.