### PR TITLE
Fix yelling.py for threads and punctuation

### DIFF
--- a/test/test_yelling.py
+++ b/test/test_yelling.py
@@ -8,7 +8,7 @@ def test_minuscule(uqcsbot: MockUQCSBot):
     """
     test minuscule string
     """
-    uqcsbot.post_message(TEST_CHANNEL_ID, 'wintermute')
+    uqcsbot.post_message(TEST_CHANNEL_ID, "wintermute")
     assert len(uqcsbot.test_messages.get(TEST_CHANNEL_ID, [])) == 2
 
 
@@ -18,7 +18,7 @@ def test_majuscule(uqcsbot: MockUQCSBot):
     """
     test majuscule string
     """
-    uqcsbot.post_message(TEST_CHANNEL_ID, 'WINTERMUTE')
+    uqcsbot.post_message(TEST_CHANNEL_ID, "WINTERMUTE")
     assert len(uqcsbot.test_messages.get(TEST_CHANNEL_ID, [])) == 1
 
 
@@ -28,7 +28,7 @@ def test_mixed(uqcsbot: MockUQCSBot):
     """
     test mixed case string
     """
-    uqcsbot.post_message(TEST_CHANNEL_ID, 'wiNTErMUTe')
+    uqcsbot.post_message(TEST_CHANNEL_ID, "wiNTErMUTe")
     assert len(uqcsbot.test_messages.get(TEST_CHANNEL_ID, [])) == 2
 
 
@@ -38,5 +38,57 @@ def test_channel(uqcsbot: MockUQCSBot):
     """
     tests outside of #yeling
     """
-    uqcsbot.post_message(TEST_CHANNEL_ID, 'wintermute')
+    uqcsbot.post_message(TEST_CHANNEL_ID, "wintermute")
     assert len(uqcsbot.test_messages.get(TEST_CHANNEL_ID, [])) == 1
+
+
+@patch("uqcsbot.scripts.yelling.in_yelling", new=lambda chan: True)
+@patch("uqcsbot.scripts.yelling.is_human", new=lambda chan: True)
+def test_thread_discreet_minuscule(uqcsbot: MockUQCSBot):
+    """
+    test minuscule string reply to thread
+    """
+    uqcsbot.post_message(TEST_CHANNEL_ID, "NEUROMANCER")
+    assert len(uqcsbot.test_messages.get(TEST_CHANNEL_ID, [])) == 1
+    thread = float(uqcsbot.test_messages.get(TEST_CHANNEL_ID, [])[-1].get('ts', 0))
+    uqcsbot.post_message(TEST_CHANNEL_ID, "wintermute", reply_broadcast=False, thread_ts=thread)
+    assert len(uqcsbot.test_messages.get(TEST_CHANNEL_ID, [])) == 3
+
+
+@patch("uqcsbot.scripts.yelling.in_yelling", new=lambda chan: True)
+@patch("uqcsbot.scripts.yelling.is_human", new=lambda chan: True)
+def test_thread_discreet_majuscule(uqcsbot: MockUQCSBot):
+    """
+    test majuscule string reply to thread
+    """
+    uqcsbot.post_message(TEST_CHANNEL_ID, "NEUROMANCER")
+    assert len(uqcsbot.test_messages.get(TEST_CHANNEL_ID, [])) == 1
+    thread = float(uqcsbot.test_messages.get(TEST_CHANNEL_ID, [])[-1].get('ts', 0))
+    uqcsbot.post_message(TEST_CHANNEL_ID, "WINTERMUTE", reply_broadcast=False, thread_ts=thread)
+    assert len(uqcsbot.test_messages.get(TEST_CHANNEL_ID, [])) == 2
+
+
+@patch("uqcsbot.scripts.yelling.in_yelling", new=lambda chan: True)
+@patch("uqcsbot.scripts.yelling.is_human", new=lambda chan: True)
+def test_thread_blatant_minuscule(uqcsbot: MockUQCSBot):
+    """
+    test minuscule string reply to thread and channel
+    """
+    uqcsbot.post_message(TEST_CHANNEL_ID, "NEUROMANCER")
+    assert len(uqcsbot.test_messages.get(TEST_CHANNEL_ID, [])) == 1
+    thread = float(uqcsbot.test_messages.get(TEST_CHANNEL_ID, [])[-1].get('ts', 0))
+    uqcsbot.post_message(TEST_CHANNEL_ID, "wintermute", reply_broadcast=True, thread_ts=thread)
+    assert len(uqcsbot.test_messages.get(TEST_CHANNEL_ID, [])) == 3
+
+
+@patch("uqcsbot.scripts.yelling.in_yelling", new=lambda chan: True)
+@patch("uqcsbot.scripts.yelling.is_human", new=lambda chan: True)
+def test_thread_blatant_majuscule(uqcsbot: MockUQCSBot):
+    """
+    test majuscule string reply to thread and channel
+    """
+    uqcsbot.post_message(TEST_CHANNEL_ID, "NEUROMANCER")
+    assert len(uqcsbot.test_messages.get(TEST_CHANNEL_ID, [])) == 1
+    thread = float(uqcsbot.test_messages.get(TEST_CHANNEL_ID, [])[-1].get('ts', 0))
+    uqcsbot.post_message(TEST_CHANNEL_ID, "WINTERMUTE", reply_broadcast=True, thread_ts=thread)
+    assert len(uqcsbot.test_messages.get(TEST_CHANNEL_ID, [])) == 2

--- a/uqcsbot/scripts/yelling.py
+++ b/uqcsbot/scripts/yelling.py
@@ -56,7 +56,7 @@ def yelling(event: dict):
         return
 
     # ensure message proper
-    if "subtype" in event:
+    if "subtype" in event and event.get("subtype") != "thread_broadcast":
         return
 
     # ensure user proper
@@ -64,7 +64,9 @@ def yelling(event: dict):
     if not is_human(user):
         return
 
+    # ignore emoji
     text = sub(r":[\w\-\+']+:", lambda m: m.group(0).upper(), event['text'], flags=UNICODE)
+    text = text.replace("&gt;", ">").replace("&lt;", "<").replace("&amp;", "&")
     # randomly select a response
     response = choice(["WHAT’S THAT‽",
                        "SPEAK UP!",
@@ -91,4 +93,8 @@ def yelling(event: dict):
 
     # check if minuscule in message, and if so, post response
     if any(c.islower() for c in text):
-        bot.post_message(channel, response)
+        if event.get("subtype") == "thread_broadcast":
+            bot.post_message(channel, response, reply_broadcast=True,
+                             thread_ts=event.get("thread_ts"))
+        else:
+            bot.post_message(channel, response, thread_ts=event.get("thread_ts"))

--- a/uqcsbot/scripts/yelling.py
+++ b/uqcsbot/scripts/yelling.py
@@ -84,7 +84,7 @@ def yelling(event: dict):
                        + " (FOR INTERNAL SCREAMING, VISIT #CRIPPLINGDEPRESSION!)",
                        ":disapproval:",
                        ":oldmanyellsatcloud:",
-                       f"DID YOU SAY \n>{mutate_minuscule(text)}".upper(),
+                       f"DID YOU SAY \n>>>{mutate_minuscule(text)}".upper(),
                        f"WHAT IS THE MEANING OF THIS ARCANE SYMBOL “{random_minuscule(text)}”‽"
                        + " I RECOGNISE IT NOT!"]
                       # the following is a reference to both "The Wicker Man" and "Nethack"


### PR DESCRIPTION
Failure to yell in threads now causes UQCS to respond in the thread (and to #yelling if reply was also to #yelling).

Now correctly fails to consider `&`, `<` and `>` as not yelling.