### PR TITLE
Add background to latex images

### DIFF
--- a/uqcsbot/scripts/latex.py
+++ b/uqcsbot/scripts/latex.py
@@ -5,7 +5,7 @@ from uqcsbot.utils.command_utils import UsageSyntaxException
 
 
 def handle_latex_internal(channel, data):
-    url = f"http://latex.codecogs.com/gif.latex?{quote(data)}"
+    url = f"http://latex.codecogs.com/gif.latex?\\bg_white&space;{quote(data)}"
     bot.post_message(
         channel,
         text=f"LaTeX render for \"{data}\"",


### PR DESCRIPTION
Changed background of latex images from transparent to white so that they can be viewed on dark mode