### PR TITLE
Slackclient v2 full update

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,9 +8,7 @@ with open(path.join(here, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 install_requires = [
-    'slackclient==1.3.1',
-    # TODO: delete this
-    'websocket-client==0.54.0',
+    'slackclient~=2.5.0',
     'requests',
     'BeautifulSoup4',
     'apscheduler',

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -2,7 +2,6 @@
 Configuration for Pytest
 """
 
-from unittest.mock import MagicMock
 from itertools import islice
 from functools import partial
 from collections import defaultdict
@@ -11,7 +10,7 @@ from typing import Optional
 import pytest
 from slack import WebClient
 import uqcsbot as uqcsbot_module
-from uqcsbot.api import APIWrapper, APIMethodProxy
+from uqcsbot.api import APIWrapper
 from uqcsbot.base import UQCSBot, Command
 from copy import deepcopy
 
@@ -158,7 +157,8 @@ class MockUQCSBot(UQCSBot):
             return channel.get(channel_type, False)
 
         if channel_type == 'all':
-            filter_function = lambda x: True
+            def filter_function(*args):
+                return True
             channel_type = 'channels'
         elif channel_type == 'channels':
             filter_function = partial(is_channel_type, channel_type='is_public')

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -9,9 +9,9 @@ from collections import defaultdict
 import time
 from typing import Optional
 import pytest
-from slackclient import SlackClient
+from slack import WebClient
 import uqcsbot as uqcsbot_module
-from uqcsbot.api import APIWrapper
+from uqcsbot.api import APIWrapper, APIMethodProxy
 from uqcsbot.base import UQCSBot, Command
 from copy import deepcopy
 
@@ -41,6 +41,10 @@ TEST_CHANNELS = {
                      'is_private': True, 'is_user_deleted': False,
                      'user': TEST_USER_ID}
 }
+for item in ['is_im', 'is_public', 'is_private', 'is_group']:
+    for chan in TEST_CHANNELS.values():
+        if item not in chan:
+            chan[item] = False
 
 
 class MockUQCSBot(UQCSBot):
@@ -50,21 +54,26 @@ class MockUQCSBot(UQCSBot):
         self.test_users = deepcopy(TEST_USERS)
         self.test_channels = deepcopy(TEST_CHANNELS)
 
-        def mocked_api_call(method, **kwargs):
+        def mocked_api_call(method, *, http_verb='POST', **kwargs):
             '''
             Called the mocked version of a Slack API call.
             '''
             mocked_method = 'mocked_' + method.replace('.', '_')
+
             if mocked_method not in dir(type(self)):
                 raise NotImplementedError(f'{method} has not been mocked.')
+            if http_verb == 'GET':
+                kwargs.update(kwargs.pop('params', {}))
+            elif http_verb == 'POST':
+                kwargs.update(kwargs.pop('json', {}))
             return getattr(self, mocked_method)(**kwargs)
 
-        self.mocked_client = MagicMock(spec=SlackClient)
+        self.mocked_client = WebClient('fake-token')
         self.mocked_client.api_call = mocked_api_call
 
     @property
     def api(self):
-        return APIWrapper(self.mocked_client)
+        return APIWrapper(self.mocked_client, self.mocked_client)
 
     def mocked_users_info(self, **kwargs):
         '''
@@ -74,7 +83,7 @@ class MockUQCSBot(UQCSBot):
 
         user = self.test_users.get(user_id)
         if user is None:
-            return {'ok': False}
+            return {'ok': False, 'error': 'test'}
 
         return {'ok': True, 'user': user}
 
@@ -88,12 +97,12 @@ class MockUQCSBot(UQCSBot):
 
         channel = self.test_channels.get(channel_id)
         if channel is None:
-            return {'ok': False}
+            return {'ok': False, 'error': 'test'}
 
         all_members = channel.get('members', [])
         sliced_members = all_members[cursor: cursor + limit + 1]
         cursor += len(sliced_members)
-        if cursor == len(all_members):
+        if cursor >= len(all_members):
             cursor = None
 
         return {'ok': True, 'members': sliced_members, 'cursor': cursor}
@@ -107,12 +116,12 @@ class MockUQCSBot(UQCSBot):
         limit = kwargs.get('limit', 100)
 
         if channel_id not in self.test_channels:
-            return {'ok': False}
+            return {'ok': False, 'error': 'test'}
 
         all_messages = self.test_messages.get(channel_id, [])[::-1]  # Most recent first
         sliced_messages = list(islice(all_messages, cursor, cursor + limit + 1))
         cursor += len(sliced_messages)
-        if cursor == len(all_messages):
+        if cursor >= len(all_messages):
             cursor = None
 
         return {'ok': True, 'messages': sliced_messages, 'cursor': cursor}
@@ -129,6 +138,12 @@ class MockUQCSBot(UQCSBot):
         '''
         return self.mocked_channels_list(channel_type='ims', **kwargs)
 
+    def mocked_conversations_list(self, **kwargs):
+        '''
+        Mocks conversations.list api call.
+        '''
+        return self.mocked_channels_list(channel_type='all', **kwargs)
+
     def mocked_channels_list(self, channel_type='channels', **kwargs):
         '''
         Mocks channels.list api call.
@@ -142,19 +157,22 @@ class MockUQCSBot(UQCSBot):
             '''
             return channel.get(channel_type, False)
 
-        if channel_type == 'channels':
+        if channel_type == 'all':
+            filter_function = lambda x: True
+            channel_type = 'channels'
+        elif channel_type == 'channels':
             filter_function = partial(is_channel_type, channel_type='is_public')
         elif channel_type == 'groups':
             filter_function = partial(is_channel_type, channel_type='is_group')
         elif channel_type == 'ims':
             filter_function = partial(is_channel_type, channel_type='is_im')
         else:
-            return {'ok': False}
+            return {'ok': False, 'error': 'test'}
 
         all_channels = list(filter(filter_function, self.test_channels.values()))
         sliced_channels = all_channels[cursor: cursor + limit + 1]
         cursor += len(sliced_channels)
-        if cursor == len(all_channels):
+        if cursor >= len(all_channels):
             cursor = None
 
         return {'ok': True, channel_type: sliced_channels, 'cursor': cursor}
@@ -169,7 +187,7 @@ class MockUQCSBot(UQCSBot):
         all_members = list(self.test_users.values())
         sliced_members = all_members[cursor: cursor + limit + 1]
         cursor += len(sliced_members)
-        if cursor == len(all_members):
+        if cursor >= len(all_members):
             cursor = None
 
         return {'ok': True, 'members': sliced_members, 'cursor': cursor}
@@ -197,7 +215,7 @@ class MockUQCSBot(UQCSBot):
         name = kwargs.get('name')
         message = self.get_channel_message(**kwargs)
         if name is None or message is None:
-            return {'ok': False}
+            return {'ok': False, 'error': 'test'}
         # Note: 'user' is not a part of Slack API for reactions.add, just a
         # convenient way to set the calling user during testing. If not passed,
         # reaction is assumed to be from bot.
@@ -227,23 +245,23 @@ class MockUQCSBot(UQCSBot):
         name = kwargs.get('name')
         message = self.get_channel_message(**kwargs)
         if name is None or message is None:
-            return {'ok': False}
+            return {'ok': False, 'error': 'test'}
         # Note: 'user' is not a part of Slack API for reactions.add, just a
         # convenient way to set the calling user during testing. If not passed,
         # reaction is assumed to be from bot.
         user = kwargs.get('user', TEST_BOT_ID)
 
         if 'reactions' not in message:
-            return {'ok': False}
+            return {'ok': False, 'error': 'test'}
 
         # Retrieves the reaction with the given name if found, else None.
         reaction_object = next((r for r in message['reactions'] if r['name'] == name), None)
 
         # Error if there was no reaction or the calling user was not a reactee.
         if reaction_object is None:
-            return {'ok': False}
+            return {'ok': False, 'error': 'test'}
         if user not in reaction_object['users']:
-            return {'ok': False}
+            return {'ok': False, 'error': 'test'}
 
         reaction_object['count'] -= 1
         reaction_object['users'].remove(user)
@@ -266,7 +284,7 @@ class MockUQCSBot(UQCSBot):
 
         channel = self.channels.get(channel_id_or_name)
         if channel is None:
-            return {'ok': False}
+            return {'ok': False, 'error': 'test'}
 
         # Strip the kwargs down to only ones which are valid for this api call.
         # Note: If there is an additional argument you need supported, add it

--- a/test/test_ascii.py
+++ b/test/test_ascii.py
@@ -3,6 +3,7 @@ Tests for ascii.py
 """
 from test.conftest import MockUQCSBot, TEST_CHANNEL_ID
 from unittest.mock import patch
+from pathlib import Path
 
 
 TEST_TEXT = "ThIS iS a TeST MesSAgE"
@@ -18,7 +19,8 @@ def mocked_get_fontslist(*args, **kwargs):
     Mocks get fontslist by retuning a local file
     containing fonts for offline testing
     """
-    with open('test/fontslist.txt', 'r') as file:
+    path = Path(__file__).parent / Path('fontslist.txt')
+    with path.open('r') as file:
         content = file.readlines()
         fontslist = []
         for i in content:

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ deps =
     flake8
     mypy
 commands =
-    coverage run --parallel-mode --source uqcsbot/ -m pytest --junitxml=pytest.xml test/
+    coverage run --parallel-mode --source uqcsbot/ -m pytest -v --junitxml=pytest.xml test/
     coverage combine
     coverage xml -o coverage.xml
     coverage report

--- a/uqcsbot/__init__.py
+++ b/uqcsbot/__init__.py
@@ -12,6 +12,7 @@ LOGGER = logging.getLogger("uqcsbot")
 
 SLACK_VERIFICATION_TOKEN = os.environ.get("SLACK_VERIFICATION_TOKEN", "")
 SLACK_BOT_TOKEN = os.environ.get("SLACK_BOT_TOKEN", "")
+SLACK_USER_TOKEN = os.environ.get("SLACK_USER_TOKEN", "")
 # Channel group which contains all the bots. Easy way to get all their ids.
 SECRET_BOT_MEETING_ROOM = 'G9JJXHF7S'
 
@@ -117,9 +118,6 @@ def import_scripts():
 
 
 def main():
-    # Import scripts
-    import_scripts()
-
     # Setup the CLI argument parser
     parser = argparse.ArgumentParser(description='Run UQCSBot')
     parser.add_argument('--dev', dest='dev',
@@ -135,9 +133,13 @@ def main():
     args = parser.parse_args()
     logging.basicConfig(level=args.log_level)
 
+    # Import scripts
+    import_scripts()
+
     # If in development mode, attempt to allocate an available bot token,
     # else stick with the default. If no bot could be allocated, exit.
     bot_token = SLACK_BOT_TOKEN
+    user_token = SLACK_USER_TOKEN
     if args.dev:
         test_bot = get_free_test_bot()
         if test_bot is None:
@@ -150,8 +152,11 @@ def main():
     if bot_token is None or bot_token == "":
         LOGGER.error("No bot token found!")
         sys.exit(1)
+    if user_token is None or user_token == "":
+        LOGGER.error("No user token found!")
+        sys.exit(1)
 
-    bot.run(bot_token, SLACK_VERIFICATION_TOKEN)
+    bot.run(user_token, bot_token)
 
 
 if __name__ == "__main__":

--- a/uqcsbot/api.py
+++ b/uqcsbot/api.py
@@ -6,7 +6,6 @@ import threading
 import logging
 from typing import (TYPE_CHECKING, List, Iterable, Optional, Generator,
                     Any, Union, TypeVar, Dict, Type)
-from typing_extensions import Literal
 if TYPE_CHECKING:
     from uqcsbot.base import UQCSBot  # noqa
 
@@ -17,10 +16,9 @@ UserT = TypeVar('UserT', bound='User')
 LOGGER = logging.getLogger(__name__)
 
 # This is used to track which client is preferred for a given method
-_CLIENT_METHOD_REGISTRY: Dict[str, Union[Literal['bot'], Literal['user']]] = {
+# Defaults to bot
+_CLIENT_METHOD_REGISTRY: Dict[str, str] = {
     'chat.postMessage': 'bot',
-    'rtm.connect': 'user',
-    'rtm.start': 'user',
 }
 
 

--- a/uqcsbot/base.py
+++ b/uqcsbot/base.py
@@ -265,7 +265,7 @@ class UQCSBot(object):
                 event
             ) for handler in handlers
         ]
-        return list(await asyncio.gather(futures, self._loop))
+        return [(await future) for future in futures]
 
     def run(self, user_token, bot_token):
         """

--- a/uqcsbot/base.py
+++ b/uqcsbot/base.py
@@ -5,7 +5,6 @@ import collections
 import asyncio
 import concurrent.futures
 import logging
-import time
 import inspect
 from contextlib import contextmanager
 from typing import Callable, Optional, Union, TypeVar, DefaultDict, Type, Any

--- a/uqcsbot/scripts/yelling.py
+++ b/uqcsbot/scripts/yelling.py
@@ -9,7 +9,8 @@ def in_yelling(channel):
     checks that channel is #yelling
     exists for test mocking
     """
-    return bot.channels.get(channel).name == "yelling"
+    chan = bot.channels.get(channel)
+    return chan and chan.name == "yelling"
 
 
 def is_human(user):


### PR DESCRIPTION
This updates our slack client and testing code to the latest version. I've also taken the liberty of prepping uqcsbot for the "two different token" aka "granular scopes" update that destroyed it last time.

Right now we're having to use an old-style token spun up specifically but if they ever reenable bot users we'll probably have to do something different there. If they never do, we should rewrite to use the events API.