### PR TITLE
Fix tests in #yelling

### DIFF
--- a/test/test_yelling.py
+++ b/test/test_yelling.py
@@ -1,5 +1,29 @@
 from test.conftest import MockUQCSBot, TEST_CHANNEL_ID
 from unittest.mock import patch
+from typing import Mapping, TypeVar, Generator, Any, List
+
+T = TypeVar('T', bound=Mapping[str, Any])
+
+
+def filter_valid_lowercases(msgs: List[T]) -> Generator[T, None, None]:
+    """
+    Sometimes UQCSbot's #yelling prompts will include lowercase chars
+    """
+    for body in msgs:
+        msg = body.get('text')
+        if msg is None:
+            continue
+        if msg.startswith('WHAT IS THE MEANING OF THIS ARCANE SYMBOL') and msg.endswith(" I RECOGNISE IT NOT!"):
+            continue
+        if msg == 'OH, NO! NOT THE `a`S! NOT THE `a`S! AAAAAHHHHH!':
+            continue
+        yield msg
+
+
+def count_lowercase_msgs(uqcsbot):
+    return len(list(
+        filter_valid_lowercases(uqcsbot.test_messages.get(TEST_CHANNEL_ID, []))
+    ))
 
 
 @patch("uqcsbot.scripts.yelling.in_yelling", new=lambda chan: True)
@@ -9,7 +33,7 @@ def test_minuscule(uqcsbot: MockUQCSBot):
     test minuscule string
     """
     uqcsbot.post_message(TEST_CHANNEL_ID, "wintermute")
-    assert len(uqcsbot.test_messages.get(TEST_CHANNEL_ID, [])) == 2
+    assert count_lowercase_msgs(uqcsbot) == 2
 
 
 @patch("uqcsbot.scripts.yelling.in_yelling", new=lambda chan: True)
@@ -19,7 +43,7 @@ def test_majuscule(uqcsbot: MockUQCSBot):
     test majuscule string
     """
     uqcsbot.post_message(TEST_CHANNEL_ID, "WINTERMUTE")
-    assert len(uqcsbot.test_messages.get(TEST_CHANNEL_ID, [])) == 1
+    assert count_lowercase_msgs(uqcsbot) == 1
 
 
 @patch("uqcsbot.scripts.yelling.in_yelling", new=lambda chan: True)
@@ -29,7 +53,7 @@ def test_mixed(uqcsbot: MockUQCSBot):
     test mixed case string
     """
     uqcsbot.post_message(TEST_CHANNEL_ID, "wiNTErMUTe")
-    assert len(uqcsbot.test_messages.get(TEST_CHANNEL_ID, [])) == 2
+    assert count_lowercase_msgs(uqcsbot) == 2
 
 
 @patch("uqcsbot.scripts.yelling.in_yelling", new=lambda chan: False)
@@ -39,7 +63,7 @@ def test_channel(uqcsbot: MockUQCSBot):
     tests outside of #yeling
     """
     uqcsbot.post_message(TEST_CHANNEL_ID, "wintermute")
-    assert len(uqcsbot.test_messages.get(TEST_CHANNEL_ID, [])) == 1
+    assert count_lowercase_msgs(uqcsbot) == 1
 
 
 @patch("uqcsbot.scripts.yelling.in_yelling", new=lambda chan: True)
@@ -49,10 +73,10 @@ def test_thread_discreet_minuscule(uqcsbot: MockUQCSBot):
     test minuscule string reply to thread
     """
     uqcsbot.post_message(TEST_CHANNEL_ID, "NEUROMANCER")
-    assert len(uqcsbot.test_messages.get(TEST_CHANNEL_ID, [])) == 1
+    assert count_lowercase_msgs(uqcsbot) == 1
     thread = float(uqcsbot.test_messages.get(TEST_CHANNEL_ID, [])[-1].get('ts', 0))
     uqcsbot.post_message(TEST_CHANNEL_ID, "wintermute", reply_broadcast=False, thread_ts=thread)
-    assert len(uqcsbot.test_messages.get(TEST_CHANNEL_ID, [])) == 3
+    assert count_lowercase_msgs(uqcsbot) == 3
 
 
 @patch("uqcsbot.scripts.yelling.in_yelling", new=lambda chan: True)
@@ -62,10 +86,10 @@ def test_thread_discreet_majuscule(uqcsbot: MockUQCSBot):
     test majuscule string reply to thread
     """
     uqcsbot.post_message(TEST_CHANNEL_ID, "NEUROMANCER")
-    assert len(uqcsbot.test_messages.get(TEST_CHANNEL_ID, [])) == 1
+    assert count_lowercase_msgs(uqcsbot) == 1
     thread = float(uqcsbot.test_messages.get(TEST_CHANNEL_ID, [])[-1].get('ts', 0))
     uqcsbot.post_message(TEST_CHANNEL_ID, "WINTERMUTE", reply_broadcast=False, thread_ts=thread)
-    assert len(uqcsbot.test_messages.get(TEST_CHANNEL_ID, [])) == 2
+    assert count_lowercase_msgs(uqcsbot) == 2
 
 
 @patch("uqcsbot.scripts.yelling.in_yelling", new=lambda chan: True)
@@ -75,10 +99,10 @@ def test_thread_blatant_minuscule(uqcsbot: MockUQCSBot):
     test minuscule string reply to thread and channel
     """
     uqcsbot.post_message(TEST_CHANNEL_ID, "NEUROMANCER")
-    assert len(uqcsbot.test_messages.get(TEST_CHANNEL_ID, [])) == 1
+    assert count_lowercase_msgs(uqcsbot) == 1
     thread = float(uqcsbot.test_messages.get(TEST_CHANNEL_ID, [])[-1].get('ts', 0))
     uqcsbot.post_message(TEST_CHANNEL_ID, "wintermute", reply_broadcast=True, thread_ts=thread)
-    assert len(uqcsbot.test_messages.get(TEST_CHANNEL_ID, [])) == 3
+    assert count_lowercase_msgs(uqcsbot) == 3
 
 
 @patch("uqcsbot.scripts.yelling.in_yelling", new=lambda chan: True)
@@ -88,7 +112,7 @@ def test_thread_blatant_majuscule(uqcsbot: MockUQCSBot):
     test majuscule string reply to thread and channel
     """
     uqcsbot.post_message(TEST_CHANNEL_ID, "NEUROMANCER")
-    assert len(uqcsbot.test_messages.get(TEST_CHANNEL_ID, [])) == 1
+    assert count_lowercase_msgs(uqcsbot) == 1
     thread = float(uqcsbot.test_messages.get(TEST_CHANNEL_ID, [])[-1].get('ts', 0))
     uqcsbot.post_message(TEST_CHANNEL_ID, "WINTERMUTE", reply_broadcast=True, thread_ts=thread)
-    assert len(uqcsbot.test_messages.get(TEST_CHANNEL_ID, [])) == 2
+    assert count_lowercase_msgs(uqcsbot) == 2

--- a/test/test_yelling.py
+++ b/test/test_yelling.py
@@ -13,7 +13,10 @@ def filter_valid_lowercases(msgs: List[T]) -> Generator[T, None, None]:
         msg = body.get('text')
         if msg is None:
             continue
-        if msg.startswith('WHAT IS THE MEANING OF THIS ARCANE SYMBOL') and msg.endswith(" I RECOGNISE IT NOT!"):
+        if (
+                msg.startswith('WHAT IS THE MEANING OF THIS ARCANE SYMBOL')
+                and msg.endswith(" I RECOGNISE IT NOT!")
+        ):
             continue
         if msg == 'OH, NO! NOT THE `a`S! NOT THE `a`S! AAAAAHHHHH!':
             continue

--- a/uqcsbot/scripts/yelling.py
+++ b/uqcsbot/scripts/yelling.py
@@ -65,7 +65,7 @@ def yelling(event: dict):
         return
 
     # ignore emoji
-    text = sub(r":[\w\-\+']+:", lambda m: m.group(0).upper(), event['text'], flags=UNICODE)
+    text = sub(r":[\w\-\+\_']+:", lambda m: m.group(0).upper(), event['text'], flags=UNICODE)
     text = text.replace("&gt;", ">").replace("&lt;", "<").replace("&amp;", "&")
     # randomly select a response
     response = choice(["WHAT’S THAT‽",


### PR DESCRIPTION
Some #yelling replies post lower case text, this allows only those replies.

Also allows underscored emojis without complaining