### PR TITLE
Fix KeyError on missing users and update committee after 2020 SGM.

### DIFF
--- a/uqcsbot/api.py
+++ b/uqcsbot/api.py
@@ -430,7 +430,7 @@ class UsersWrapper(object):
             self._bot.on(mtype, attr)
 
     def _on_user_change(self, evt):
-        user = self._users_by_id[evt['user']['id']]
+        user = self._users_by_id.get(evt['user']['id'], None)
         if user is not None:
             user.update_from_dict(evt['user'])
         else:

--- a/uqcsbot/api.py
+++ b/uqcsbot/api.py
@@ -392,6 +392,7 @@ class UsersWrapper(object):
             for page in self._bot.api.users.list.paginate():
                 for user in page['members']:
                     self._add_user(user)
+            self._initialised = True
 
     def reload(self):
         self._initialised = False
@@ -430,17 +431,18 @@ class UsersWrapper(object):
             self._bot.on(mtype, attr)
 
     def _on_user_change(self, evt):
-        user = self._users_by_id.get(evt['user']['id'], None)
-        if user is not None:
-            user.update_from_dict(evt['user'])
-        else:
-            LOGGER.error("User change event for unknown user - adding")
-            with self._lock:
+        with self._lock:
+            user = self._users_by_id.get(evt['user']['id'], None)
+            if user is not None:
+                user.update_from_dict(evt['user'])
+            else:
                 self._add_user(evt['user'])
 
     def _on_team_join(self, evt):
-        with self._lock:
-            self._add_user(evt['user'])
+        # Because the _on_team_join event is not reliably happening before 
+        # _on_user_change, just handle both updating and adding new users in
+        # _on_user_change.
+        self._on_user_change(evt)
 
 
 class User(object):

--- a/uqcsbot/scripts/welcome.py
+++ b/uqcsbot/scripts/welcome.py
@@ -13,31 +13,41 @@ SLACK_PROFILE_GUIDE = "https://slack.com/intl/en-au/help/articles/204092246-Edit
 
 WELCOME_MESSAGES = [    # Welcome messages sent to new members
     "Hey there! Welcome to the UQCS Slack!",
+
     "This is the first time I've seen you, so you're probably new here.",
+
     f"I'm UQCSbot, your friendly (<{UQCSBOT_REPO}|open source>) robot helper!",
+
     "You can type `help` here, or `!help` anywhere else to find out what I can do!",
+
     "We've got a bunch of generic channels (e.g. <#C0D0BEYPM|banter>,"
     " <#C0DKX7NGP|games>, <#CB2K0Q09K|adulting>) along with many subject-specific"
     " ones (e.g <#C0MAN4BRS|csse1001>, <#C0Q2KTCK1|math1051>, <#C0DKSDGLE|csse2310>).",
+
     "To find and join a channel, tap on the channels header in the sidebar.",
+
     "The UQCS Slack is a friendly community and we have a code of conduct in place to ensure our "
     "members' well-being and safety. You can view a copy of this code of conduct here:"
     "\n>https://github.com/UQComputingSociety/code-of-conduct",
+
     "UQCS elects a leadership committee every year who also serve as our friendly Slack admins. "
     "This year's committee consists of:\n"
     ">Madhav (<@UFB9R5QFM>), Matthew (<@U8JN3NR1C>), Bradley (<@U4AJ0EDE3>), "
-    "Sanni (<@UM55HGLUT>), Jack (<@U29STGM63>), James (<@U1H1R3NGK>), Kenton (<@U9LMBPJG5>), "
-    "Nick (<@U0LG4V4NN>), Olivia (<@UA25BSPGT>), Raghav (<@U73H0R0QH>), "
-    "and Brian (<@UCYC0TKMM>)\n"
+    "Alby (<@U4J1AGST1>), Sanni (<@UM55HGLUT>), Paul (<@UTYTKAB89>), "
+    "James C. (<@U1H1R3NGK>), James D. (<@U9D6J8HB8>), Kenton (<@U9LMBPJG5>), "
+    "Nick (<@U0LG4V4NN>), and Olivia (<@UA25BSPGT>).\n"
     "If you have any questions or need to get in touch, please reach out to them.",
+
     "We also hold heaps of events events during semester. For a list of upcoming events check "
     "out the <#C0D0G52PP|events> channel and use the command `!events`.",
+
     "Don't forget to let people know who you are! Choose a profile pic, set a "
     "status and tell us what you're studying. These small touches help the UQCS "
     "community understand who you are and, in turn, help you to more quickly "
     "become an integral part of the society. If you need any help, check out "
     f"this handy <{SLACK_PROFILE_GUIDE}|guide> or ask one admins for help! "
     "Once that's all done, why not introduce yourself in <#C2R8W0YPJ|general>.",
+
     "Be sure to download the Slack <https://slack.com/downloads|desktop> and "
     f"<{SLACK_DOWNLOAD_GUIDE}|mobile> apps as well, so you'll be able to catch any important "
     "announcements, and again, welcome to the UQ Computing Society :)"


### PR DESCRIPTION
Not sure why the KeyError problem occurs. Welcome seems to be firing correctly in the live version but did not work on testing without this change.

Apart from that, updated committee users after 2020 SGM (add Alby, James D., Paul; remove Jack, Raghav, Brian).

Also spaced out messages to show where the pauses will be between message parts.

KeyError exception below:
```
Traceback (most recent call last):
  File "/usr/lib/python3.6/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/lib/python3.6/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/srv/uqcsbot/lib/python3.6/site-packages/uqcsbot/__main__.py", line 2, in <module>
    main()
  File "/srv/uqcsbot/lib/python3.6/site-packages/uqcsbot/__init__.py", line 160, in main
    bot.run(user_token, bot_token)
  File "/srv/uqcsbot/lib/python3.6/site-packages/uqcsbot/base.py", line 342, in run
    run_future(self.rtm_client.start())
  File "/usr/lib/python3.6/asyncio/base_events.py", line 484, in run_until_complete
    return future.result()
  File "/srv/uqcsbot/lib/python3.6/site-packages/slack/rtm/client.py", line 339, in _connect_and_read
    await self._read_messages()
  File "/srv/uqcsbot/lib/python3.6/site-packages/slack/rtm/client.py", line 390, in _read_messages
    await self._dispatch_event(event, data=payload)
  File "/srv/uqcsbot/lib/python3.6/site-packages/uqcsbot/base.py", line 126, in _dispatch_event
    await coro
  File "/usr/lib/python3.6/concurrent/futures/thread.py", line 56, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/srv/uqcsbot/lib/python3.6/site-packages/uqcsbot/api.py", line 433, in _on_user_change
    user = self._users_by_id[evt['user']['id']]
KeyError: 'U012LEHF5FX'
```