### PR TITLE
Add E302 to ignore list for flake8 explicitly

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -18,6 +18,6 @@ commands =
     coverage xml -o coverage.xml
     coverage report
     mypy --ignore-missing-imports --no-strict-optional uqcsbot/
-    flake8 --extend-ignore=F541 --max-line-length=100 uqcsbot/
+    flake8 --extend-ignore=F541,E302 --max-line-length=100 uqcsbot/
     mypy --ignore-missing-imports --no-strict-optional test/
-    flake8 --extend-ignore=F541 --max-line-length=100 test/
+    flake8 --extend-ignore=F541,E302 --max-line-length=100 test/


### PR DESCRIPTION
Watching a great demo this evening (thanks @bradleysigma), we encountered a minor setback that the tests passed [on this PR](https://github.com/UQComputingSociety/uqcsbot/pull/536/files) (uqcsbot-pr build: https://jenkins.uqcs.org/job/uqcsbot-pr/578/console) but then after it was merged, testing on the master branch failed (uqcsbot build: https://jenkins.uqcs.org/job/uqcsbot/221/console), which prevented the bot from being deployed.

I saw from the log in the two jenkins builds that the one from the _uqcsbot-pr_ job passes `--extend-ignore=F541,E302` to the `flake8` invocation, but only `--extend-ignore=F541` is passed in the _uqcsbot_ job.

I suspect that the jenkins jobs or workspaces might have different flake8 configurations somehow. This change doesn't address the configuration difference (you might prefer that approach if you know where it's bringing the `E302` ignoring from in the uqcsbot-pr job), but otherwise this should bring consistency in test results a different way!

