### PR TITLE
Create Channel Log

### DIFF
--- a/test/test_channel_log.py
+++ b/test/test_channel_log.py
@@ -1,0 +1,16 @@
+from test.conftest import MockUQCSBot
+from test.helpers import (generate_event_object, MESSAGE_TYPE_CHANNEL_CREATED)
+
+
+def test_channel_log(uqcsbot: MockUQCSBot):
+    """
+    Test channel_log for a member creating a channel
+    """
+    uqcsbot._run_handlers(generate_event_object(MESSAGE_TYPE_CHANNEL_CREATED,
+                                                channel={'id': 'uqcs-meta',
+                                                         'name': 'uqcs-meta',
+                                                         'is_public': True}))
+
+    message = uqcsbot.test_messages.get('uqcs-meta', [])
+    assert len(message) == 1
+    assert message[0]['text'] == 'New Channel Created: <#uqcs-meta|uqcs-meta>'

--- a/test/test_emoji_log.py
+++ b/test/test_emoji_log.py
@@ -10,6 +10,9 @@ def test_emoji_log(uqcsbot: MockUQCSBot):
     """
     events = [
         generate_event_object(MESSAGE_TYPE_CHANNEL_CREATED,
+                              channel={'id': 'uqcs-meta', 'name': 'uqcs-meta',
+                                       'is_public': True}),
+        generate_event_object(MESSAGE_TYPE_CHANNEL_CREATED,
                               channel={'id': 'emoji-request', 'name': 'emoji-request',
                                        'is_public': True}),
         # normal add comes with an image URL

--- a/test/test_emoji_log.py
+++ b/test/test_emoji_log.py
@@ -9,6 +9,8 @@ def test_emoji_log(uqcsbot: MockUQCSBot):
     Test !emoji_log for a member adding or removing emoji.
     """
     events = [
+        # next event triggers the channel_log function,
+        # and so a #uqcs-meta channel needs to exist to post to
         generate_event_object(MESSAGE_TYPE_CHANNEL_CREATED,
                               channel={'id': 'uqcs-meta', 'name': 'uqcs-meta',
                                        'is_public': True}),

--- a/uqcsbot/scripts/channel_log.py
+++ b/uqcsbot/scripts/channel_log.py
@@ -1,0 +1,13 @@
+from uqcsbot import bot
+
+
+@bot.on("channel_created")
+def channel_log(evt: dict):
+    """
+    Notes when channels are created in #uqcs-meta
+
+    @no_help
+    """
+    bot.post_message(bot.channels.get("uqcs-meta"),
+                     'New Channel Created: '
+                     + f'<#{evt.get("channel").get("id")}|{evt.get("channel").get("name")}>')


### PR DESCRIPTION
Whenever a channel is created, announces in `#uqcs-meta`.
(Public channels only.)

![image](https://user-images.githubusercontent.com/42644678/90360845-15010900-e0a0-11ea-83e2-329f74011aee.png)
