### PR TITLE
`!help command` to respond in same channel

### DIFF
--- a/test/test_help.py
+++ b/test/test_help.py
@@ -1,0 +1,13 @@
+from test.conftest import MockUQCSBot, TEST_CHANNEL_ID
+
+
+def test_help_help(uqcsbot: MockUQCSBot):
+    """
+    Tests `!help help`
+    """
+    uqcsbot.post_message(TEST_CHANNEL_ID, '!help help')
+    messages = uqcsbot.test_messages.get(TEST_CHANNEL_ID, [])
+    assert len(messages) == 2
+    assert messages[-1]['text'] == (">>>`!help [COMMAND]` - Display the helper docstring"
+                                    + " for the given command. If unspecified, will return"
+                                    + "the helper docstrings for all commands.")

--- a/test/test_help.py
+++ b/test/test_help.py
@@ -8,6 +8,6 @@ def test_help_help(uqcsbot: MockUQCSBot):
     uqcsbot.post_message(TEST_CHANNEL_ID, '!help help')
     messages = uqcsbot.test_messages.get(TEST_CHANNEL_ID, [])
     assert len(messages) == 2
-    assert messages[-1]['text'] == (">>>`!help [COMMAND]` - Display the helper docstring"
+    assert messages[-1]['text'] == (">>> `!help [COMMAND]` - Display the helper docstring"
                                     + " for the given command. If unspecified, will return"
                                     + "the helper docstrings for all commands.")

--- a/test/test_help.py
+++ b/test/test_help.py
@@ -10,4 +10,4 @@ def test_help_help(uqcsbot: MockUQCSBot):
     assert len(messages) == 2
     assert messages[-1]['text'] == (">>> `!help [COMMAND]` - Display the helper docstring"
                                     + " for the given command. If unspecified, will return"
-                                    + "the helper docstrings for all commands.")
+                                    + " the helper docstrings for all commands. ")

--- a/uqcsbot/scripts/help.py
+++ b/uqcsbot/scripts/help.py
@@ -9,10 +9,16 @@ def handle_help(command: Command):
     `!help [COMMAND]` - Display the helper docstring for the given command.
     If unspecified, will return the helper docstrings for all commands.
     """
+
+    # get helper docs
     helper_docs = get_helper_docs(command.arg)
     if len(helper_docs) == 0:
         message = 'Could not find any helper docstrings.'
     else:
         message = '>>>' + '\n'.join(helper_docs)
-    user_direct_channel = bot.channels.get(command.user_id)
-    bot.post_message(user_direct_channel, message)
+
+    # post helper docs
+    if command.arg:
+        command.reply_with(bot, message)
+    else:
+        bot.post_message(command.user_id, message, as_user=True)


### PR DESCRIPTION
`!help` (with no arguments) still responds via direct message.